### PR TITLE
Follow-ups: fix typo, update metadata schemas, rename modelType.

### DIFF
--- a/backend/schema/heat_pump.ts
+++ b/backend/schema/heat_pump.ts
@@ -25,4 +25,4 @@ export const HEAT_PUMP_SCHEMA = {
 } as const;
 
 export type HeatPump = FromSchema<typeof HEAT_PUMP_SCHEMA>;
-export type HeatPumpModelGenerated = Omit<HeatPump, "brandName" | "modelType">;
+export type HeatPumpModelGenerated = Omit<HeatPump, "brandName">;

--- a/backend/schema/heat_pump_dryer.ts
+++ b/backend/schema/heat_pump_dryer.ts
@@ -10,7 +10,10 @@ export const heatPumpDryerProperties = {
     type: "number",
   },
 } as const;
-export const requiredHeatPumpDryer = ["capacity", "combinedEnergyFactor"] as const;
+export const requiredHeatPumpDryer = [
+  "capacity",
+  "combinedEnergyFactor",
+] as const;
 
 export const HEAT_PUMP_DRYER_SCHEMA = {
   title: "Heat Pump Dryer",
@@ -20,18 +23,9 @@ export const HEAT_PUMP_DRYER_SCHEMA = {
     ...coreProperties,
     ...heatPumpDryerProperties,
   },
-  required: [
-    ...requiredMetadata,
-    ...requiredCore,
-    ...requiredHeatPumpDryer,
-  ],
+  required: [...requiredMetadata, ...requiredCore, ...requiredHeatPumpDryer],
   additionalProperties: false,
 } as const;
 
-export type HeatPumpDryer = FromSchema<
-  typeof HEAT_PUMP_DRYER_SCHEMA
->;
-export type HeatPumpDryerModelGenerated = Omit<
-  HeatPumpDryer,
-  "brandName" | "modelType"
->;
+export type HeatPumpDryer = FromSchema<typeof HEAT_PUMP_DRYER_SCHEMA>;
+export type HeatPumpDryerModelGenerated = Omit<HeatPumpDryer, "brandName">;

--- a/backend/schema/heat_pump_water_heater.ts
+++ b/backend/schema/heat_pump_water_heater.ts
@@ -13,7 +13,11 @@ export const heatPumpWaterHeaterProperties = {
     type: "number",
   },
 } as const;
-export const requiredHeatPumpWaterHeater = ["tankCapacityGallons", "uniformEnergyFactor", "firstHourRating"] as const;
+export const requiredHeatPumpWaterHeater = [
+  "tankCapacityGallons",
+  "uniformEnergyFactor",
+  "firstHourRating",
+] as const;
 
 export const HEAT_PUMP_WATER_HEATER_SCHEMA = {
   title: "Heat Pump Water Heater",
@@ -36,5 +40,5 @@ export type HeatPumpWaterHeater = FromSchema<
 >;
 export type HeatPumpWaterHeaterModelGenerated = Omit<
   HeatPumpWaterHeater,
-  "brandName" | "modelType"
+  "brandName"
 >;

--- a/backend/schema/metadata.ts
+++ b/backend/schema/metadata.ts
@@ -4,12 +4,12 @@ export const BRANDS = {
 } as const;
 export type Brand = keyof typeof BRANDS;
 
-export const MODEL_TYPES = {
+export const APPLIANCE_TYPES = {
   heat_pump: "heat_pump",
   heat_pump_water_heater: "heat_pump_water_heater",
   heat_pump_dryer: "heat_pump_dryer",
 } as const;
-export type ModelType = keyof typeof MODEL_TYPES;
+export type ApplianceType = keyof typeof APPLIANCE_TYPES;
 
 export const metadataProperties = {
   brandName: {
@@ -19,14 +19,13 @@ export const metadataProperties = {
   modelNumber: {
     type: "string",
   },
-  modelVairant: {
+  modelVariant: {
     type: "string",
-    enum: Object.keys(MODEL_TYPES),
   },
 } as const;
 
 export const requiredMetadata = [
   "brandName",
   "modelNumber",
-  "modelVairant",
+  "modelVariant",
 ] as const;

--- a/backend/src/dbutil.ts
+++ b/backend/src/dbutil.ts
@@ -1,76 +1,85 @@
 import * as dt from "../schema/appliance";
 
-export function findWaterHeater(tankCapacity: number, uniformEnergyFactor: number, firstHourRating: number) {
+export function findWaterHeater(
+  tankCapacity: number,
+  uniformEnergyFactor: number,
+  firstHourRating: number
+) {
   return dummyWaterHeaters;
 }
 
-export function findDryer(soundLevel: number, combinedEnergyFactor: number, capacity: number) {
+export function findDryer(
+  soundLevel: number,
+  combinedEnergyFactor: number,
+  capacity: number
+) {
   return dummyDryers;
 }
 
-const dummyWaterHeaters: dt.HeatPumpWaterHeater[] = [{
-  brandName: "Rheem",
-  modelNumber: "GEH50DFEJ2RA",
-  modelVairant: "701460",
-  tankCapacityGallons: 60,
-  weightInKg: 71.214,
-  widthInCm: 50,
-  heightInCm: 160.02,
-  lengthInCm: 50,
-  amperage: 3.67,
-  voltage: 120,
-  uniformEnergyFactor: 2.6,
-  firstHourRating: 60,
-},
-{
-  brandName: "Rheem",
-  modelNumber: "HP10-80H42DV",
-  modelVairant: "701460",
-  tankCapacityGallons: 70,
-  weightInKg: 71.214,
-  widthInCm: 50,
-  heightInCm: 160.02,
-  lengthInCm: 50,
-  amperage: 3.67,
-  voltage: 120,
-  uniformEnergyFactor: 2.7,
-  firstHourRating: 70,
-},
-{
-  brandName: "Rheem",
-  modelNumber: "RE2H80R10B-12CWT",
-  modelVairant: "701460",
-  tankCapacityGallons: 70,
-  weightInKg: 71.214,
-  widthInCm: 50,
-  heightInCm: 160.02,
-  lengthInCm: 50,
-  amperage: 3.67,
-  voltage: 120,
-  uniformEnergyFactor: 2.8,
-  firstHourRating: 50,
-},
-{
-  brandName: "Rheem",
-  modelNumber: "RE22SR10B-12CWT",
-  modelVairant: "701460",
-  tankCapacityGallons: 60,
-  weightInKg: 71.214,
-  widthInCm: 50,
-  heightInCm: 160.02,
-  lengthInCm: 50,
-  amperage: 3.67,
-  voltage: 120,
-  uniformEnergyFactor: 2.9,
-  firstHourRating: 60,
-},
+const dummyWaterHeaters: dt.HeatPumpWaterHeater[] = [
+  {
+    brandName: "Rheem",
+    modelNumber: "GEH50DFEJ2RA",
+    modelVariant: "701460",
+    tankCapacityGallons: 60,
+    weightInKg: 71.214,
+    widthInCm: 50,
+    heightInCm: 160.02,
+    lengthInCm: 50,
+    amperage: 3.67,
+    voltage: 120,
+    uniformEnergyFactor: 2.6,
+    firstHourRating: 60,
+  },
+  {
+    brandName: "Rheem",
+    modelNumber: "HP10-80H42DV",
+    modelVariant: "701460",
+    tankCapacityGallons: 70,
+    weightInKg: 71.214,
+    widthInCm: 50,
+    heightInCm: 160.02,
+    lengthInCm: 50,
+    amperage: 3.67,
+    voltage: 120,
+    uniformEnergyFactor: 2.7,
+    firstHourRating: 70,
+  },
+  {
+    brandName: "Rheem",
+    modelNumber: "RE2H80R10B-12CWT",
+    modelVariant: "701460",
+    tankCapacityGallons: 70,
+    weightInKg: 71.214,
+    widthInCm: 50,
+    heightInCm: 160.02,
+    lengthInCm: 50,
+    amperage: 3.67,
+    voltage: 120,
+    uniformEnergyFactor: 2.8,
+    firstHourRating: 50,
+  },
+  {
+    brandName: "Rheem",
+    modelNumber: "RE22SR10B-12CWT",
+    modelVariant: "701460",
+    tankCapacityGallons: 60,
+    weightInKg: 71.214,
+    widthInCm: 50,
+    heightInCm: 160.02,
+    lengthInCm: 50,
+    amperage: 3.67,
+    voltage: 120,
+    uniformEnergyFactor: 2.9,
+    firstHourRating: 60,
+  },
 ];
 
 const dummyDryers: dt.HeatPumpDryer[] = [
   {
     brandName: "Rheem",
     modelNumber: "XJ-75F",
-    modelVairant: "701460",
+    modelVariant: "701460",
     weightInKg: 71.214,
     widthInCm: 50,
     heightInCm: 160.02,
@@ -84,7 +93,7 @@ const dummyDryers: dt.HeatPumpDryer[] = [
   {
     brandName: "Rheem",
     modelNumber: "XJ-75F",
-    modelVairant: "701460",
+    modelVariant: "701460",
     weightInKg: 71.214,
     widthInCm: 50,
     heightInCm: 160.02,
@@ -98,7 +107,7 @@ const dummyDryers: dt.HeatPumpDryer[] = [
   {
     brandName: "Rheem",
     modelNumber: "LM-40K",
-    modelVairant: "701460",
+    modelVariant: "701460",
     weightInKg: 71.214,
     widthInCm: 50,
     heightInCm: 160.02,
@@ -112,7 +121,7 @@ const dummyDryers: dt.HeatPumpDryer[] = [
   {
     brandName: "Rheem",
     modelNumber: "AB-65R",
-    modelVairant: "701460",
+    modelVariant: "701460",
     weightInKg: 71.214,
     widthInCm: 50,
     heightInCm: 160.02,
@@ -123,4 +132,4 @@ const dummyDryers: dt.HeatPumpDryer[] = [
     combinedEnergyFactor: 8,
     capacity: 9,
   },
-]
+];

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,38 +1,55 @@
-import { FastifyInstance, FastifyReply, FastifyRequest, FastifyServerOptions } from 'fastify'
+import {
+  FastifyInstance,
+  FastifyReply,
+  FastifyRequest,
+  FastifyServerOptions,
+} from "fastify";
 import * as db from "./dbutil";
 
-export default async function (instance: FastifyInstance, opts: FastifyServerOptions, done) {
+export default async function (
+  instance: FastifyInstance,
+  opts: FastifyServerOptions,
+  done
+) {
+  instance.get("/", async (req: FastifyRequest, res: FastifyReply) => {
+    res.code(200).send(`Hello electrical-machine API`);
+  });
 
-    instance.get('/', async (req: FastifyRequest, res: FastifyReply) => {
-        res.code(200).send(`Hello electrical-machine API`)
-    })
+  // https://electric-machines-h6x1.vercel.app/api/appliance?applianceType=hpwh&capacity=40&urf=2.5&fhr=60
+  // https://electric-machines-h6x1.vercel.app/api/appliance?applianceType=hpd&soundLevel=62&cef=7.0&capacity=6.0
+  instance.get(
+    "/api/appliance",
+    async (req: FastifyRequest, res: FastifyReply) => {
+      var foundModels = handleAppliance(req);
+      res
+        .code(200)
+        .header("Content-Type", "application/json; charset=utf-8")
+        .send(foundModels);
+    }
+  );
 
-    // https://electric-machines-h6x1.vercel.app/api/appliance?modelType=hpwh&capacity=40&urf=2.5&fhr=60
-    // https://electric-machines-h6x1.vercel.app/api/appliance?modelType=hpd&soundLevel=62&cef=7.0&capacity=6.0
-    instance.get('/api/appliance', async (req: FastifyRequest, res: FastifyReply) => {
-        var foundModels = handleAppliance(req)
-        res.code(200)
-        .header('Content-Type', 'application/json; charset=utf-8')
-        .send(foundModels)
-    })
-
-    done()
+  done();
 }
 
 function handleAppliance(req: FastifyRequest) {
-    // TODO: check how to put multiple schemas under one request parser instead of handroll one...
-    var modelType = req.query['modelType']
-    switch (modelType) {
-        case "hpwh":
-            var tankCapacity: number = Number(req.query['capacity'])
-            var uniformEnergyFactor: number = Number(req.query['uef'])
-            var firstHourRating: number = Number(req.query['fhr'])
-            return db.findWaterHeater(tankCapacity, uniformEnergyFactor, firstHourRating)
-        case "hpd":
-            var soundLevel: number = Number(req.query['soundLevel'])
-            var combinedEnergyFactor: number = Number(req.query['cef'])
-            var capacity: number = Number(req.query['capacity'])
-            return db.findDryer(soundLevel, combinedEnergyFactor, capacity)
-        default: return [];
-    }
+  // TODO: check how to put multiple schemas under one request parser instead of handroll one...
+  var applianceType = req.query["applianceType"];
+  switch (applianceType) {
+    case "hpwh":
+      var tankCapacity: number = Number(req.query["capacity"]);
+      var uniformEnergyFactor: number = Number(req.query["uef"]);
+      var firstHourRating: number = Number(req.query["fhr"]);
+      return db.findWaterHeater(
+        tankCapacity,
+        uniformEnergyFactor,
+        firstHourRating
+      );
+    case "hpd":
+      var soundLevel: number = Number(req.query["soundLevel"]);
+      var combinedEnergyFactor: number = Number(req.query["cef"]);
+      var capacity: number = Number(req.query["capacity"]);
+      return db.findDryer(soundLevel, combinedEnergyFactor, capacity);
+    default:
+      return [];
+  }
 }

--- a/data/heat-pumps/rheem/endeavor-line-prestige-rp18az/metadata.json
+++ b/data/heat-pumps/rheem/endeavor-line-prestige-rp18az/metadata.json
@@ -1,4 +1,4 @@
 {
   "brandName": "rheem",
-  "modelType": "heat_pump"
+  "applianceType": "heat_pump"
 }

--- a/pipeline/src/metadata.ts
+++ b/pipeline/src/metadata.ts
@@ -4,7 +4,7 @@ import { Brand } from "../../backend/schema/metadata";
 
 export type Metadata = {
   brandName?: Brand;
-  modelType?: string;
+  applianceType?: string;
 };
 
 export async function retrieveMetadata(directory: string): Promise<Metadata> {

--- a/pipeline/src/parse_tables.ts
+++ b/pipeline/src/parse_tables.ts
@@ -11,8 +11,9 @@ import {
 
 import { GptWrapper } from "./gpt_wrapper";
 import { glob } from "glob";
-import { MODEL_TYPES, ModelType } from "../../backend/schema/metadata";
+import { APPLIANCE_TYPES } from "../../backend/schema/metadata";
 import {
+  HEAT_PUMP_DRYER_METADATA,
   HEAT_PUMP_METADATA,
   HEAT_PUMP_WATER_HEATER_METADATA,
   SpecsMetadata,
@@ -82,16 +83,18 @@ async function main() {
         }
 
         const metadata = await retrieveMetadata(applianceFolder);
-        if (!("modelType" in metadata)) {
-          throw new Error("modelType not set in metadata");
+        if (!("applianceType" in metadata)) {
+          throw new Error("applianceType not set in metadata");
         }
-        const modelType = metadata.modelType;
+        const applianceType = metadata.applianceType;
 
         let modelMetadata: SpecsMetadata<ModelGeneratedAppliance>;
-        if (modelType === MODEL_TYPES.heat_pump) {
+        if (applianceType === APPLIANCE_TYPES.heat_pump) {
           modelMetadata = HEAT_PUMP_METADATA;
-        } else if (modelType === MODEL_TYPES.heat_pump_water_heater) {
+        } else if (applianceType === APPLIANCE_TYPES.heat_pump_water_heater) {
           modelMetadata = HEAT_PUMP_WATER_HEATER_METADATA;
+        } else if (applianceType === APPLIANCE_TYPES.heat_pump_dryer) {
+          modelMetadata = HEAT_PUMP_DRYER_METADATA;
         } else {
           throw new Error(
             "No model metadata configured for this appliance type"

--- a/pipeline/src/prompt.ts
+++ b/pipeline/src/prompt.ts
@@ -17,7 +17,7 @@ export function renderSystemPrompt<T>(metadata: SpecsMetadata<T>) {
 You will be given the output of a table that was read from a PDF and converted
 to JSON. The tables contain technical specifications about heat pumps.
 The tables may contain data for multiple appliance models, and your task is to
-return valid JSON with one key-value record per model. 
+return valid JSON with one key-value record per model.
 
 There is a schema with fields you can try to match, but you can include data from the
 tables that is not in the schema. Do not return null values. The only required field is

--- a/pipeline/src/schemas.ts
+++ b/pipeline/src/schemas.ts
@@ -1,4 +1,5 @@
 import { HeatPumpModelGenerated } from "../../backend/schema/heat_pump";
+import { HeatPumpDryerModelGenerated } from "../../backend/schema/heat_pump_dryer";
 import { HeatPumpWaterHeaterModelGenerated } from "../../backend/schema/heat_pump_water_heater";
 
 export type FieldMetadata = { description: string };
@@ -9,6 +10,10 @@ export const HEAT_PUMP_METADATA: SpecsMetadata<HeatPumpModelGenerated> = {
   modelNumber: {
     description:
       "Reqired field. The appliance's model number. Will typically correspond to an entire column or row in the table.",
+  },
+  modelVariant: {
+    description:
+      "An optional, more fine-grained number similar to the model number that describes the type of appliance.",
   },
   tonnage: {
     description: "The nominal tonnage of the appliance.",
@@ -45,6 +50,10 @@ export const HEAT_PUMP_WATER_HEATER_METADATA: SpecsMetadata<HeatPumpWaterHeaterM
       description:
         "Reqired field. The appliance's model number. Will typically correspond to an entire column or row in the table.",
     },
+    modelVariant: {
+      description:
+        "An optional, more fine-grained number similar to the model number that describes the type of appliance.",
+    },
     tankCapacityGallons: {
       description: "The tank capacity in gallons.",
     },
@@ -71,5 +80,55 @@ export const HEAT_PUMP_WATER_HEATER_METADATA: SpecsMetadata<HeatPumpWaterHeaterM
     },
     soundLevelMax: {
       description: "The maximum sound level in decibels.",
+    },
+    uniformEnergyFactor: {
+      description: "The UEF or Uniform Energy Factor, an efficiency metric.",
+    },
+    firstHourRating: {
+      description:
+        "A performance metric indicating the amount of hot water a water heater can supply in an hour after being fully heated.",
+    },
+  };
+
+export const HEAT_PUMP_DRYER_METADATA: SpecsMetadata<HeatPumpDryerModelGenerated> =
+  {
+    modelNumber: {
+      description:
+        "Reqired field. The appliance's model number. Will typically correspond to an entire column or row in the table.",
+    },
+    modelVariant: {
+      description:
+        "An optional, more fine-grained number similar to the model number that describes the type of appliance.",
+    },
+    capacity: {
+      description: "The capacity of the dryer in cubic feet.",
+    },
+    weightInKg: {
+      description: "The weight or operating weight of the appliance.",
+    },
+    lengthInCm: {
+      description: "The operating length of the equipment in centimeters.",
+    },
+    widthInCm: {
+      description: "The operating width of the equipment in centimeters.",
+    },
+    heightInCm: {
+      description: "The operating height of the equipment in centimeters.",
+    },
+    amperage: {
+      description: "The required amperage for the equipment.",
+    },
+    voltage: {
+      description: "The required voltage for the equipment.",
+    },
+    soundLevelMin: {
+      description: "The minimum sound level in decibels.",
+    },
+    soundLevelMax: {
+      description: "The maximum sound level in decibels.",
+    },
+    combinedEnergyFactor: {
+      description:
+        "The Combined Energy Factor, an efficiency metric for dryers.",
     },
   };

--- a/pipeline/src/validate_data.ts
+++ b/pipeline/src/validate_data.ts
@@ -10,7 +10,10 @@ import { Appliance } from "../../backend/schema/appliance";
 import { HEAT_PUMP_SCHEMA } from "../../backend/schema/heat_pump";
 import { glob } from "glob";
 import { retrieveMetadata } from "./metadata";
-import { MODEL_TYPES, requiredMetadata } from "../../backend/schema/metadata";
+import {
+  APPLIANCE_TYPES,
+  requiredMetadata,
+} from "../../backend/schema/metadata";
 import { HEAT_PUMP_WATER_HEATER_SCHEMA } from "../../backend/schema/heat_pump_water_heater";
 
 const SPECS_FILE_BASE = "../data/";
@@ -29,8 +32,8 @@ async function initializeValidators() {
   const validators: { [index: string]: ValidateFunction<Appliance> } = {};
   const ajv = new Ajv({ allErrors: true });
 
-  validators[MODEL_TYPES.heat_pump] = ajv.compile(HEAT_PUMP_SCHEMA);
-  validators[MODEL_TYPES.heat_pump_water_heater] = ajv.compile(
+  validators[APPLIANCE_TYPES.heat_pump] = ajv.compile(HEAT_PUMP_SCHEMA);
+  validators[APPLIANCE_TYPES.heat_pump_water_heater] = ajv.compile(
     HEAT_PUMP_WATER_HEATER_SCHEMA
   );
 
@@ -69,7 +72,7 @@ async function main() {
         const specs = Array.isArray(filtered) ? filtered : [filtered];
         for (const spec of specs) {
           const augmentedSpec = { ...spec, ...metadataToCopy };
-          const validate = validators[metadataToCopy.modelType!];
+          const validate = validators[metadataToCopy.applianceType!];
           if (validate(augmentedSpec)) {
             valid.push(augmentedSpec);
           } else {

--- a/pipeline/test/prompt.test.ts
+++ b/pipeline/test/prompt.test.ts
@@ -29,13 +29,14 @@ t.test("render prompt correctly", (t) => {
 You will be given the output of a table that was read from a PDF and converted
 to JSON. The tables contain technical specifications about heat pumps.
 The tables may contain data for multiple appliance models, and your task is to
-return valid JSON that matches the following schema, with one record per
-appliance. All values in the schema are optional except the modelNumber. Do not
-return null values. The key for this output should be "data".
+return valid JSON with one key-value record per model.
+
+There is a schema with fields you can try to match, but you can include data from the
+tables that is not in the schema. Do not return null values. The only required field is
+modelNumber. The key for this output should be "data".
 
 You should also output the mapping you construct from column names
-in the tables to the fields in the schema. It is not expected that you will use
-all of the columns in the table. The key for this output should be "mapping".
+in the tables to the fields in the schema. The key for this output should be "mapping".
 
 If there are numeric row/column numbers in the table, you can ignore them.
 If the table is empty of any meaningful data, you can return an empty object for


### PR DESCRIPTION
This renames modelType to applianceType, corrects the Vairant misspelling to Variant, and updates the metadata schemas which were out of date with the new backend schemas.

We should figure out how to easily compile the whole monorepo since as is it's quite easy for changes in one corner to not get propagated to the others.