### PR TITLE
More changes to the schema to better reflect what we'll collect.

### DIFF
--- a/backend/schema/core.ts
+++ b/backend/schema/core.ts
@@ -11,7 +11,7 @@ export const coreProperties = {
   heightInCm: {
     type: "number",
   },
-  amperage: {
+  electricBreakerSize: {
     type: "number",
   },
   voltage: {
@@ -30,6 +30,6 @@ export const requiredCore = [
   "lengthInCm",
   "widthInCm",
   "heightInCm",
-  "amperage",
+  "electricBreakerSize",
   "voltage",
 ] as const;

--- a/backend/schema/heat_pump.ts
+++ b/backend/schema/heat_pump.ts
@@ -1,12 +1,16 @@
 import { FromSchema } from "json-schema-to-ts";
-import { metadataProperties, requiredMetadata } from "./metadata";
+import {
+  ManuallyEntered,
+  metadataProperties,
+  requiredMetadata,
+} from "./metadata";
 import { coreProperties, requiredCore } from "./core";
 
-const tonnage = ["1", "1.5", "2", "2.5", "3", "3.5", "4", "4.5", "5"];
+const tonnage = [1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5];
 
 export const heatPumpProperties = {
   tonnage: {
-    type: "string",
+    type: "number",
     enum: tonnage,
   },
 } as const;
@@ -25,4 +29,4 @@ export const HEAT_PUMP_SCHEMA = {
 } as const;
 
 export type HeatPump = FromSchema<typeof HEAT_PUMP_SCHEMA>;
-export type HeatPumpModelGenerated = Omit<HeatPump, "brandName">;
+export type HeatPumpModelGenerated = Omit<HeatPump, ManuallyEntered>;

--- a/backend/schema/heat_pump_dryer.ts
+++ b/backend/schema/heat_pump_dryer.ts
@@ -1,5 +1,9 @@
 import { FromSchema } from "json-schema-to-ts";
-import { metadataProperties, requiredMetadata } from "./metadata";
+import {
+  ManuallyEntered,
+  metadataProperties,
+  requiredMetadata,
+} from "./metadata";
 import { coreProperties, requiredCore } from "./core";
 
 export const heatPumpDryerProperties = {
@@ -28,4 +32,4 @@ export const HEAT_PUMP_DRYER_SCHEMA = {
 } as const;
 
 export type HeatPumpDryer = FromSchema<typeof HEAT_PUMP_DRYER_SCHEMA>;
-export type HeatPumpDryerModelGenerated = Omit<HeatPumpDryer, "brandName">;
+export type HeatPumpDryerModelGenerated = Omit<HeatPumpDryer, ManuallyEntered>;

--- a/backend/schema/heat_pump_water_heater.ts
+++ b/backend/schema/heat_pump_water_heater.ts
@@ -1,5 +1,9 @@
 import { FromSchema } from "json-schema-to-ts";
-import { metadataProperties, requiredMetadata } from "./metadata";
+import {
+  ManuallyEntered,
+  metadataProperties,
+  requiredMetadata,
+} from "./metadata";
 import { coreProperties, requiredCore } from "./core";
 
 export const heatPumpWaterHeaterProperties = {
@@ -40,5 +44,5 @@ export type HeatPumpWaterHeater = FromSchema<
 >;
 export type HeatPumpWaterHeaterModelGenerated = Omit<
   HeatPumpWaterHeater,
-  "brandName"
+  ManuallyEntered
 >;

--- a/backend/schema/metadata.ts
+++ b/backend/schema/metadata.ts
@@ -22,10 +22,10 @@ export const metadataProperties = {
   modelVariant: {
     type: "string",
   },
+  sourceUrl: {
+    type: "string",
+  },
 } as const;
 
-export const requiredMetadata = [
-  "brandName",
-  "modelNumber",
-  "modelVariant",
-] as const;
+export const requiredMetadata = ["brandName", "modelNumber"] as const;
+export type ManuallyEntered = "brandName" | "sourceUrl";

--- a/data/heat-pumps/rheem/endeavor-line-prestige-rp18az/metadata.json
+++ b/data/heat-pumps/rheem/endeavor-line-prestige-rp18az/metadata.json
@@ -1,4 +1,5 @@
 {
   "brandName": "rheem",
-  "applianceType": "heat_pump"
+  "applianceType": "heat_pump",
+  "sourceUrl": "https://files.myrheem.com/webpartners/ProductDocuments/3552AAA5-F72D-44EA-A96A-7CFA6DF1D3F9.pdf"
 }

--- a/pipeline/src/metadata.ts
+++ b/pipeline/src/metadata.ts
@@ -4,6 +4,7 @@ import { Brand } from "../../backend/schema/metadata";
 
 export type Metadata = {
   brandName?: Brand;
+  sourceUrl?: string;
   applianceType?: string;
 };
 

--- a/pipeline/src/schemas.ts
+++ b/pipeline/src/schemas.ts
@@ -9,14 +9,15 @@ export type SpecsMetadata<T> = { [K in keyof T]: FieldMetadata };
 export const HEAT_PUMP_METADATA: SpecsMetadata<HeatPumpModelGenerated> = {
   modelNumber: {
     description:
-      "Reqired field. The appliance's model number. Will typically correspond to an entire column or row in the table.",
+      "Required field. The appliance's model number. Will typically correspond to an entire column or row in the table.",
   },
   modelVariant: {
     description:
       "An optional, more fine-grained number similar to the model number that describes the type of appliance.",
   },
   tonnage: {
-    description: "The nominal tonnage of the appliance.",
+    description:
+      "The nominal tonnage of the appliance. Format as a number even if it is supplied as a string.",
   },
   weightInKg: {
     description: "The weight or operating weight of the appliance.",
@@ -30,8 +31,9 @@ export const HEAT_PUMP_METADATA: SpecsMetadata<HeatPumpModelGenerated> = {
   heightInCm: {
     description: "The operating height of the equipment in centimeters.",
   },
-  amperage: {
-    description: "The required amperage for the equipment.",
+  electricBreakerSize: {
+    description:
+      "The required breaker size for the equipment. May also be called Maximum Overcurrent Protection (MOP).",
   },
   voltage: {
     description: "The required voltage for the equipment.",
@@ -48,7 +50,7 @@ export const HEAT_PUMP_WATER_HEATER_METADATA: SpecsMetadata<HeatPumpWaterHeaterM
   {
     modelNumber: {
       description:
-        "Reqired field. The appliance's model number. Will typically correspond to an entire column or row in the table.",
+        "Required field. The appliance's model number. Will typically correspond to an entire column or row in the table.",
     },
     modelVariant: {
       description:
@@ -69,8 +71,9 @@ export const HEAT_PUMP_WATER_HEATER_METADATA: SpecsMetadata<HeatPumpWaterHeaterM
     heightInCm: {
       description: "The operating height of the equipment in centimeters.",
     },
-    amperage: {
-      description: "The required amperage for the equipment.",
+    electricBreakerSize: {
+      description:
+        "The required breaker size for the equipment. May also be called Maximum Overcurrent Protection (MOP).",
     },
     voltage: {
       description: "The required voltage for the equipment.",
@@ -94,7 +97,7 @@ export const HEAT_PUMP_DRYER_METADATA: SpecsMetadata<HeatPumpDryerModelGenerated
   {
     modelNumber: {
       description:
-        "Reqired field. The appliance's model number. Will typically correspond to an entire column or row in the table.",
+        "Required field. The appliance's model number. Will typically correspond to an entire column or row in the table.",
     },
     modelVariant: {
       description:
@@ -115,8 +118,9 @@ export const HEAT_PUMP_DRYER_METADATA: SpecsMetadata<HeatPumpDryerModelGenerated
     heightInCm: {
       description: "The operating height of the equipment in centimeters.",
     },
-    amperage: {
-      description: "The required amperage for the equipment.",
+    electricBreakerSize: {
+      description:
+        "The required breaker size for the equipment. May also be called Maximum Overcurrent Protection (MOP).",
     },
     voltage: {
       description: "The required voltage for the equipment.",

--- a/pipeline/src/validate_data.ts
+++ b/pipeline/src/validate_data.ts
@@ -10,10 +10,7 @@ import { Appliance } from "../../backend/schema/appliance";
 import { HEAT_PUMP_SCHEMA } from "../../backend/schema/heat_pump";
 import { glob } from "glob";
 import { retrieveMetadata } from "./metadata";
-import {
-  APPLIANCE_TYPES,
-  requiredMetadata,
-} from "../../backend/schema/metadata";
+import { APPLIANCE_TYPES } from "../../backend/schema/metadata";
 import { HEAT_PUMP_WATER_HEATER_SCHEMA } from "../../backend/schema/heat_pump_water_heater";
 
 const SPECS_FILE_BASE = "../data/";
@@ -73,7 +70,8 @@ async function main() {
         }
 
         const metadata = await retrieveMetadata(applianceFolder);
-        const metadataToCopy = _.pick(metadata, requiredMetadata);
+        const columnsToCopy = ["brandName", "sourceUrl"];
+        const metadataToCopy = _.pick(metadata, columnsToCopy);
 
         const specs = Array.isArray(filtered["data"])
           ? filtered["data"]


### PR DESCRIPTION
Amperage encompasses a few different concepts, and what we've seen more consistently so far is more akin to electric breaker size than rated amps, though we may collect that later too.

I've also added the source URL as metadata worth storing and including in the final record.

@rickycheah ccing you so you know that that URL is something you'll be able to play with on the frontend soon. It's probably good to have a "more info" link in the table (or perhaps just the link behind the model number) so that people who want to know more have a data source.