### PR TITLE
Backend search capacity in range instead of >=

### DIFF
--- a/backend/src/dbutil.ts
+++ b/backend/src/dbutil.ts
@@ -11,13 +11,15 @@ export const DRYERS: dt.HeatPumpDryer[] = JSON.parse(
 );
 
 export function findWaterHeater(
-  tankCapacity: number,
+  tankCapacityMin: number,
+  tankCapacityMax: number,
   uniformEnergyFactor: number,
   firstHourRating: number
 ) {
   return WATER_HEATERS.filter((heater) => {
     return (
-      heater.tankCapacityGallons >= tankCapacity &&
+      heater.tankCapacityGallons >= tankCapacityMin &&
+      heater.tankCapacityGallons <= tankCapacityMax &&
       heater.uniformEnergyFactor >= uniformEnergyFactor &&
       heater.firstHourRating >= firstHourRating
     );
@@ -25,15 +27,17 @@ export function findWaterHeater(
 }
 
 export function findDryer(
+  capacityMin: number,
+  capacityMax: number,
   soundLevel: number,
-  combinedEnergyFactor: number,
-  capacity: number
+  combinedEnergyFactor: number
 ) {
   return DRYERS.filter((dryer) => {
     return (
+      dryer.capacity >= capacityMin &&
+      dryer.capacity <= capacityMax &&
       dryer.soundLevelMax <= soundLevel &&
-      dryer.combinedEnergyFactor >= combinedEnergyFactor &&
-      dryer.capacity >= capacity
+      dryer.combinedEnergyFactor >= combinedEnergyFactor
     );
   });
 }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -15,8 +15,8 @@ export default async function (
     res.code(200).send(`Hello electrical-machine API`);
   });
 
-  // https://electric-machines-h6x1.vercel.app/api/v1/appliance?applianceType=hpwh&capacity=40&urf=2.5&fhr=60
-  // https://electric-machines-h6x1.vercel.app/api/v1/appliance?applianceType=hpd&soundLevel=62&cef=7.0&capacity=6.0
+  // https://electric-machines-h6x1.vercel.app/api/v1/appliance?applianceType=hpwh&capacityMin=40&capacityMax=60&urf=2.5&fhr=60
+  // https://electric-machines-h6x1.vercel.app/api/v1/appliance?applianceType=hpd&soundLevel=62&cef=7.0&capacityMin=6.0&capacityMax=7.0
   instance.get(
     "/api/v1/appliance",
     async (req: FastifyRequest, res: FastifyReply) => {
@@ -47,19 +47,17 @@ function handleAppliance(req: FastifyRequest) {
   var applianceType = req.query["applianceType"];
   switch (applianceType) {
     case "hpwh":
-      var tankCapacity: number = Number(req.query["capacity"]);
+      var tankCapacityMin: number = Number(req.query["capacityMin"]);
+      var tankCapacityMax: number = Number(req.query["capacityMax"]);
       var uniformEnergyFactor: number = Number(req.query["uef"]);
       var firstHourRating: number = Number(req.query["fhr"]);
-      return db.findWaterHeater(
-        tankCapacity,
-        uniformEnergyFactor,
-        firstHourRating
-      );
+      return db.findWaterHeater(tankCapacityMin, tankCapacityMax, uniformEnergyFactor, firstHourRating);
     case "hpd":
-      var soundLevel: number = Number(req.query["soundLevel"]);
+      var capacityMin: number = Number(req.query["capacityMin"]);
+      var capacityMax: number = Number(req.query["capacityMax"]);
       var combinedEnergyFactor: number = Number(req.query["cef"]);
-      var capacity: number = Number(req.query["capacity"]);
-      return db.findDryer(soundLevel, combinedEnergyFactor, capacity);
+      var soundLevel: number = Number(req.query["soundLevel"]);
+      return db.findDryer(capacityMin, capacityMax, combinedEnergyFactor, soundLevel);
     default:
       return [];
   }

--- a/frontend/app/components/appliances-forms/HeatPumpDryer.tsx
+++ b/frontend/app/components/appliances-forms/HeatPumpDryer.tsx
@@ -34,7 +34,7 @@ const HeatPumpDryer = () => {
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    const apiUrl = `https://electric-machines-h6x1.vercel.app/api/v1/appliance?applianceType=hpd&soundLevel=${soundLevel}&cef=${combinedEnergyFactor}&capacity=${capacity}`;
+    const apiUrl = `https://electric-machines-h6x1.vercel.app/api/v1/appliance?applianceType=hpd&soundLevel=${soundLevel}&cef=${combinedEnergyFactor}&capacityMin=${capacity}&capacityMax=${capacity+1}`;
     // console.log(apiUrl);
     const response = await fetch(apiUrl);
     const data = await response.json();

--- a/frontend/app/components/appliances-forms/HeatPumpWaterHeaterForm.tsx
+++ b/frontend/app/components/appliances-forms/HeatPumpWaterHeaterForm.tsx
@@ -37,7 +37,7 @@ const HeatPumpWaterHeaterForm = () => {
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    const apiUrl = `https://electric-machines-h6x1.vercel.app/api/v1/appliance?applianceType=hpwh&capacity=${tankCapacityGallons}&uef=${uniformEnergyFactor}&fhr=${firstHourRating}`;
+    const apiUrl = `https://electric-machines-h6x1.vercel.app/api/v1/appliance?applianceType=hpwh&capacityMin=${tankCapacityGallons}&capacityMax=${tankCapacityGallons+10}&uef=${uniformEnergyFactor}&fhr=${firstHourRating}`;
     // console.log(apiUrl);
     const response = await fetch(apiUrl);
     const data = await response.json();


### PR DESCRIPTION
As per the front end tool-tip suggested, we should only return tank capacity in water heater and capacity in dryer within a certain range instead of all the appliances that has bigger capacities.
![image](https://github.com/datu925/electric-machines/assets/24417119/0c201468-7d01-4416-b7e7-ba0126833dbf)

Let me know your thoughts on this.
