### PR TITLE
More flexible unit for data collection

### DIFF
--- a/backend/data/dryers.json
+++ b/backend/data/dryers.json
@@ -3,10 +3,16 @@
     "brandName": "General Electric",
     "modelNumber": "PFD87ESSVWW/ES(P/M)VRS 240V",
     "sourceUrl": "https://products-salsify.geappliances.com/image/upload/s--XdcWb9Qq--/tjtu3zcktpaufsk10vrm.pdf?_ga=2.104748992.1570831524.1711587971-928897490.1711587971",
-    "weightInKg": 50,
-    "widthInCm": 50,
-    "heightInCm": 160.02,
-    "lengthInCm": 50,
+    "weight":{
+      "value": 50,
+      "unit": "kg"
+    },
+    "dimensions": {
+      "width": 71.2,
+      "height": 101,
+      "length": 86.4,
+      "unit": "cm"
+    },
     "electricBreakerSize": 30,
     "voltage": 240,
     "soundLevelMax": 63,
@@ -17,10 +23,16 @@
     "brandName": "General Electric",
     "modelNumber": "PFD87ESSVWW/ES(P/M)VRS 208V",
     "sourceUrl": "https://products-salsify.geappliances.com/image/upload/s--XdcWb9Qq--/tjtu3zcktpaufsk10vrm.pdf?_ga=2.104748992.1570831524.1711587971-928897490.1711587971",
-    "weightInKg": 50,
-    "widthInCm": 50,
-    "heightInCm": 160.02,
-    "lengthInCm": 50,
+    "weight":{
+      "value": 50,
+      "unit": "kg"
+    },
+    "dimensions": {
+      "width": 71.2,
+      "height": 101,
+      "length": 86.4,
+      "unit": "cm"
+    },
     "electricBreakerSize": 30,
     "voltage": 208,
     "soundLevelMax": 62,
@@ -31,10 +43,16 @@
     "brandName": "Samsung",
     "modelNumber": "DV25B6900EW",
     "sourceUrl": "https://image-us.samsung.com/SamsungUS/home/home-appliances/dryers/electric/dv25b6900ew-a2/2022_DV25B6900EW_V5.pdf",
-    "weightInKg": 42,
-    "widthInCm": 50,
-    "heightInCm": 160.02,
-    "lengthInCm": 50,
+    "weight":{
+      "value": 88.4,
+      "unit": "lb"
+    },
+    "dimensions": {
+      "width": 23.625,
+      "height": 33.5,
+      "length": 25.8125,
+      "unit": "in"
+    },
     "electricBreakerSize": 30,
     "voltage": 240,
     "soundLevelMax": 65,
@@ -45,10 +63,16 @@
     "brandName": "Samsung",
     "modelNumber": "DVE55A7700V",
     "sourceUrl": "https://image-us.samsung.com/SamsungUS/home/home-appliances/pdf/272023/v3/2021_DVE55A7700V_V10.pdf",
-    "weightInKg": 54,
-    "widthInCm": 50,
-    "heightInCm": 160.02,
-    "lengthInCm": 50,
+    "weight":{
+      "value": 119,
+      "unit": "lb"
+    },
+    "dimensions": {
+      "width": 27,
+      "height": 45.8125,
+      "length": 30.25,
+      "unit": "in"
+    },
     "electricBreakerSize": 30,
     "voltage": 240,
     "soundLevelMax": 65,
@@ -59,10 +83,16 @@
     "brandName": "Samsung",
     "modelNumber": "DVE47CG3500",
     "sourceUrl": "https://image-us.samsung.com/SamsungUS/home/home-appliances/dryers/electric/dve47cg3500va3/2023_DVE47CG3500_V5.pdf",
-    "weightInKg": 54,
-    "widthInCm": 50,
-    "heightInCm": 160.02,
-    "lengthInCm": 50,
+    "weight":{
+      "value": 119,
+      "unit": "lb"
+    },
+    "dimensions": {
+      "width": 27,
+      "height": 45.0625,
+      "length": 30.25,
+      "unit": "in"
+    },
     "electricBreakerSize": 30,
     "voltage": 240,
     "soundLevelMax": 65,

--- a/backend/data/hvac.json
+++ b/backend/data/hvac.json
@@ -3,10 +3,16 @@
     "brandName": "Rheem",
     "modelNumber": "RP1724",
     "sourceUrl": "https://files.myrheem.com/webpartners/ProductDocuments/E693F41A-B92C-455E-9A7D-0869E189E279.pdf",
-    "weightInKg": 2000,
-    "widthInCm": 85.7,
-    "heightInCm": 88.9,
-    "lengthInCm": 85.7,
+    "weight":{
+      "value": 223,
+      "unit": "lb"
+    },
+    "dimensions": {
+      "width": 33.75,
+      "height": 35,
+      "length": 33.75,
+      "unit": "in"
+    },
     "electricBreakerSize": 35,
     "voltage": 230,
     "tonnage": 2
@@ -15,10 +21,16 @@
     "brandName": "Rheem",
     "modelNumber": "RP1748",
     "sourceUrl": "https://files.myrheem.com/webpartners/ProductDocuments/E693F41A-B92C-455E-9A7D-0869E189E279.pdf",
-    "weightInKg": 4000,
-    "widthInCm": 90.8,
-    "heightInCm": 99.0,
-    "lengthInCm": 90.8,
+    "weight":{
+      "value": 250,
+      "unit": "lb"
+    },
+    "dimensions": {
+      "width": 35.75,
+      "height": 39,
+      "length": 35.75,
+      "unit": "in"
+    },
     "electricBreakerSize": 45,
     "voltage": 230,
     "tonnage": 4

--- a/backend/data/stove.json
+++ b/backend/data/stove.json
@@ -3,16 +3,24 @@
     "brandName": "General Electric",
     "modelNumber": "PHS930BLTS",
     "sourceUrl": "https://www.geappliances.com/appliance/GE-Profile-30-Smart-Slide-In-Front-Control-Induction-and-Convection-Range-PHS930BLTS",
-    "weightInKg": 90.7185,
-    "widthInCm": 75.8825,
-    "heightInCm": 94.615,
-    "lengthInCm": 71.755,
+    "weight":{
+        "value": 200,
+        "unit": "lb"
+      },
+    "dimensions": {
+      "width": 29.875,
+      "height": 37.25,
+      "length": 28.25,
+      "unit": "in"
+    },
     "electricBreakerSize": 40,
     "voltage": 240,
     "numElements": 5,
     "cooktopsPowerType": "induction",
-    "ovenCapacity": 5.3,
-    "ovenCapacityUnit": "cu ft",
+    "ovenCapacity": {
+      "value": 5.3,
+      "unit": "cuft"
+    },
     "bakeWattage": 2850,
     "broilerWattage": 4000,
     "convectionWattage": 2500
@@ -21,16 +29,24 @@
     "brandName": "General Electric",
     "modelNumber": "PB965YPFS",
     "sourceUrl": "https://www.geappliances.com/appliance/GE-Profile-30-Smart-Free-Standing-Electric-Double-Oven-Convection-Range-with-No-Preheat-Air-Fry-PB965YPFS",
-    "weightInKg": 73.0284,
-    "widthInCm": 75.8825,
-    "heightInCm": 120.65,
-    "lengthInCm": 71.755,
+    "weight":{
+      "value": 161,
+      "unit": "lb"
+    },
+    "dimensions": {
+      "width": 29.875,
+      "height": 47.5,
+      "length": 28.25,
+      "unit": "in"
+    },
     "electricBreakerSize": 40,
     "voltage": 240,
     "numElements": 5,
     "cooktopsPowerType": "electric",
-    "ovenCapacity": 6.6,
-    "ovenCapacityUnit": "cu ft",
+    "ovenCapacity": {
+      "value": 6.6,
+      "unit": "cuft"
+    },
     "bakeWattage": 2650,
     "broilerWattage": 3600
   }

--- a/backend/data/water-heaters.json
+++ b/backend/data/water-heaters.json
@@ -4,10 +4,16 @@
     "modelNumber": "PROPH40 T2 RH375-30",
     "sourceUrl": "https://files.myrheem.com/webpartnerspublic/ProductDocuments/65DF1261-86D9-4756-AAAD-F403E9FF124A.pdf",
     "tankCapacityGallons": 40,
-    "weightInKg": 71.214,
-    "widthInCm": 50,
-    "heightInCm": 160.02,
-    "lengthInCm": 50,
+    "weight":{
+      "value": 157,
+      "unit": "lb"
+    },
+    "dimensions": {
+      "width": 20.5,
+      "height": 62.3125,
+      "length": 25.375,
+      "unit": "in"
+    },
     "electricBreakerSize": 30,
     "voltage": 240,
     "uniformEnergyFactor": 3.83,
@@ -18,10 +24,16 @@
     "modelNumber": "PROPH50 T2 RH375-30",
     "sourceUrl": "https://files.myrheem.com/webpartnerspublic/ProductDocuments/65DF1261-86D9-4756-AAAD-F403E9FF124A.pdf",
     "tankCapacityGallons": 50,
-    "weightInKg": 71.214,
-    "widthInCm": 50,
-    "heightInCm": 160.02,
-    "lengthInCm": 50,
+    "weight":{
+      "value": 178,
+      "unit": "lb"
+    },
+    "dimensions": {
+      "width": 22.5,
+      "height": 61.75,
+      "length": 27.375,
+      "unit": "in"
+    },
     "electricBreakerSize": 30,
     "voltage": 240,
     "uniformEnergyFactor": 3.88,
@@ -32,10 +44,16 @@
     "modelNumber": "PROPH65 T2 RH375-30",
     "sourceUrl": "https://files.myrheem.com/webpartnerspublic/ProductDocuments/65DF1261-86D9-4756-AAAD-F403E9FF124A.pdf",
     "tankCapacityGallons": 65,
-    "weightInKg": 71.214,
-    "widthInCm": 50,
-    "heightInCm": 160.02,
-    "lengthInCm": 50,
+    "weight":{
+      "value": 225,
+      "unit": "lb"
+    },
+    "dimensions": {
+      "width": 24.625,
+      "height": 64.1875,
+      "length": 29.5,
+      "unit": "in"
+    },
     "electricBreakerSize": 30,
     "voltage": 240,
     "uniformEnergyFactor": 4.05,
@@ -46,10 +64,16 @@
     "modelNumber": "PROPH80 T2 RH375-30",
     "sourceUrl": "https://files.myrheem.com/webpartnerspublic/ProductDocuments/65DF1261-86D9-4756-AAAD-F403E9FF124A.pdf",
     "tankCapacityGallons": 80,
-    "weightInKg": 71.214,
-    "widthInCm": 50,
-    "heightInCm": 160.02,
-    "lengthInCm": 50,
+    "weight":{
+      "value": 244,
+      "unit": "lb"
+    },
+    "dimensions": {
+      "width": 24.625,
+      "height": 74.1875,
+      "length": 29.5,
+      "unit": "in"
+    },
     "electricBreakerSize": 30,
     "voltage": 240,
     "uniformEnergyFactor": 4.07,
@@ -60,10 +84,16 @@
     "modelNumber": "PROPH40 T2 RH375-15",
     "sourceUrl": "https://files.myrheem.com/webpartnerspublic/ProductDocuments/65DF1261-86D9-4756-AAAD-F403E9FF124A.pdf",
     "tankCapacityGallons": 40,
-    "weightInKg": 71.214,
-    "widthInCm": 50,
-    "heightInCm": 160.02,
-    "lengthInCm": 50,
+    "weight":{
+      "value": 157,
+      "unit": "lb"
+    },
+    "dimensions": {
+      "width": 20.5,
+      "height": 62.3125,
+      "length": 25.375,
+      "unit": "in"
+    },
     "electricBreakerSize": 15,
     "voltage": 240,
     "uniformEnergyFactor": 3.45,
@@ -74,10 +104,16 @@
     "modelNumber": "PROPH50 T2 RH375-15",
     "sourceUrl": "https://files.myrheem.com/webpartnerspublic/ProductDocuments/65DF1261-86D9-4756-AAAD-F403E9FF124A.pdf",
     "tankCapacityGallons": 50,
-    "weightInKg": 71.214,
-    "widthInCm": 50,
-    "heightInCm": 160.02,
-    "lengthInCm": 50,
+    "weight":{
+      "value": 178,
+      "unit": "lb"
+    },
+    "dimensions": {
+      "width": 22.5,
+      "height": 61.75,
+      "length": 27.375,
+      "unit": "in"
+    },
     "electricBreakerSize": 15,
     "voltage": 240,
     "uniformEnergyFactor": 3.75,
@@ -88,10 +124,16 @@
     "modelNumber": "PROPH65 T2 RH375-15",
     "sourceUrl": "https://files.myrheem.com/webpartnerspublic/ProductDocuments/65DF1261-86D9-4756-AAAD-F403E9FF124A.pdf",
     "tankCapacityGallons": 65,
-    "weightInKg": 71.214,
-    "widthInCm": 50,
-    "heightInCm": 160.02,
-    "lengthInCm": 50,
+    "weight":{
+      "value": 225,
+      "unit": "lb"
+    },
+    "dimensions": {
+      "width": 24.625,
+      "height": 64.1875,
+      "length": 29.5,
+      "unit": "in"
+    },
     "electricBreakerSize": 15,
     "voltage": 240,
     "uniformEnergyFactor": 3.55,
@@ -102,10 +144,16 @@
     "modelNumber": "PROPH80 T2 RH375-15",
     "sourceUrl": "https://files.myrheem.com/webpartnerspublic/ProductDocuments/65DF1261-86D9-4756-AAAD-F403E9FF124A.pdf",
     "tankCapacityGallons": 80,
-    "weightInKg": 71.214,
-    "widthInCm": 50,
-    "heightInCm": 160.02,
-    "lengthInCm": 50,
+    "weight":{
+      "value": 244,
+      "unit": "lb"
+    },
+    "dimensions": {
+      "width": 24.625,
+      "height": 74.1875,
+      "length": 29.5,
+      "unit": "in"
+    },
     "electricBreakerSize": 15,
     "voltage": 240,
     "uniformEnergyFactor": 3.7,
@@ -116,10 +164,16 @@
     "modelNumber": "HPTV-66",
     "sourceUrl": "https://assets.hotwater.com/damroot/Original/10008/ARXSS00123.pdf",
     "tankCapacityGallons": 68,
-    "weightInKg": 71.214,
-    "widthInCm": 50,
-    "heightInCm": 160.02,
-    "lengthInCm": 50,
+    "weight":{
+      "value": 289,
+      "unit": "lb"
+    },
+    "dimensions": {
+      "width": 26.5,
+      "height": 61.5,
+      "length": 26.5,
+      "unit": "in"
+    },
     "electricBreakerSize": 15,
     "voltage": 120,
     "uniformEnergyFactor": 3.2,
@@ -130,10 +184,16 @@
     "modelNumber": "HPTV-80",
     "sourceUrl": "https://assets.hotwater.com/damroot/Original/10008/ARXSS00123.pdf",
     "tankCapacityGallons": 82,
-    "weightInKg": 71.214,
-    "widthInCm": 50,
-    "heightInCm": 160.02,
-    "lengthInCm": 50,
+    "weight":{
+      "value": 307,
+      "unit": "lb"
+    },
+    "dimensions": {
+      "width": 26.5,
+      "height": 69,
+      "length": 26.5,
+      "unit": "in"
+    },
     "electricBreakerSize": 15,
     "voltage": 120,
     "uniformEnergyFactor": 3,
@@ -144,10 +204,16 @@
     "modelNumber": "HPTU-50N",
     "sourceUrl": "https://assets.hotwater.com/damroot/Original/10001/AOSXE50007.pdf",
     "tankCapacityGallons": 46,
-    "weightInKg": 71.214,
-    "widthInCm": 50,
-    "heightInCm": 160.02,
-    "lengthInCm": 50,
+    "weight":{
+      "value": 196,
+      "unit": "lb"
+    },
+    "dimensions": {
+      "width": 22,
+      "height": 63,
+      "length": 22,
+      "unit": "in"
+    },
     "electricBreakerSize": 30,
     "voltage": 240,
     "uniformEnergyFactor": 3.45,
@@ -158,10 +224,16 @@
     "modelNumber": "HPTU-66N",
     "sourceUrl": "https://assets.hotwater.com/damroot/Original/10001/AOSXE50007.pdf",
     "tankCapacityGallons": 67,
-    "weightInKg": 71.214,
-    "widthInCm": 50,
-    "heightInCm": 160.02,
-    "lengthInCm": 50,
+    "weight":{
+      "value": 289,
+      "unit": "lb"
+    },
+    "dimensions": {
+      "width": 27,
+      "height": 61,
+      "length": 27,
+      "unit": "in"
+    },
     "electricBreakerSize": 30,
     "voltage": 240,
     "uniformEnergyFactor": 3.45,
@@ -172,10 +244,16 @@
     "modelNumber": "HPTU-80N",
     "sourceUrl": "https://assets.hotwater.com/damroot/Original/10001/AOSXE50007.pdf",
     "tankCapacityGallons": 82,
-    "weightInKg": 71.214,
-    "widthInCm": 50,
-    "heightInCm": 160.02,
-    "lengthInCm": 50,
+    "weight":{
+      "value": 307,
+      "unit": "lb"
+    },
+    "dimensions": {
+      "width": 27,
+      "height": 69,
+      "length": 27,
+      "unit": "in"
+    },
     "electricBreakerSize": 30,
     "voltage": 240,
     "uniformEnergyFactor": 3.45,

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "convert-units": "^3.0.0-beta.6",
         "dotenv": "^10.0.0",
         "fastify": "^4.26.2"
       },
@@ -1696,6 +1697,11 @@
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
+    },
+    "node_modules/convert-units": {
+      "version": "3.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/convert-units/-/convert-units-3.0.0-beta.6.tgz",
+      "integrity": "sha512-KTWaWzdnadB/tulZ9QfP63hMXdyXLl/XEZhYVMdLqlgwdgNxxslbtZ4It8/u1Jzty90Pmylvpje4y8Xa2Smrpg=="
     },
     "node_modules/cookie": {
       "version": "0.6.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,6 +21,7 @@
     "typescript": "^5.4.2"
   },
   "dependencies": {
+    "convert-units": "^3.0.0-beta.6",
     "dotenv": "^10.0.0",
     "fastify": "^4.26.2"
   }

--- a/backend/schema/core.ts
+++ b/backend/schema/core.ts
@@ -1,15 +1,21 @@
 export const coreProperties = {
-  weightInKg: {
-    type: "number",
+  weight: {
+    type: "object",
+    properties: {
+      value: { type: "number" },
+      unit: { type: "string" },
+    },
+    required: ["value", "unit"],
   },
-  lengthInCm: {
-    type: "number",
-  },
-  widthInCm: {
-    type: "number",
-  },
-  heightInCm: {
-    type: "number",
+  dimensions: {
+    type: "object",
+    properties: {
+      length: { type: "number" },
+      width: { type: "number" },
+      height: { type: "number" },
+      unit: { type: "string" },
+    },
+    required: ["length", "width", "height", "unit"],
   },
   electricBreakerSize: {
     type: "number",
@@ -26,10 +32,8 @@ export const coreProperties = {
 } as const;
 
 export const requiredCore = [
-  "weightInKg",
-  "lengthInCm",
-  "widthInCm",
-  "heightInCm",
+  "weight",
+  "dimensions",
   "electricBreakerSize",
   "voltage",
 ] as const;

--- a/backend/schema/stove.ts
+++ b/backend/schema/stove.ts
@@ -17,10 +17,11 @@ export const StoveProperties = {
     enum: powerType,
   },
   ovenCapacity: {
-    type: "number"
-  },
-  ovenCapacityUnit: {
-    type: "string"
+    type: "object",
+    properties: {
+      value: { type: "number" },
+      unit: { type: "string" },
+    }
   },
   bakeWattage: {
     type: "number"

--- a/backend/src/controller/appliance_controller.ts
+++ b/backend/src/controller/appliance_controller.ts
@@ -33,14 +33,14 @@ function handleAppliance(request: FastifyRequest<ar.ApplianceRequest>) {
   const { applianceType } = request.query as ar.ApplianceRequest
   switch (applianceType.toLowerCase()) {
     case "hpwh":
-      let hpwh = ar.setOptionalsForWaterHeater(request.query as ar.HeatPumpWaterHeaterRequest);
-      return db.queryWaterHeater(hpwh);
+      let hpwhRequest = request.query as ar.HeatPumpWaterHeaterRequest
+      return db.queryWaterHeater(ar.toWaterHeaterQuery(hpwhRequest));
     case "hpd":
-      let hpd = ar.setOptionalsForDryer(request.query as ar.HeatPumpDryerRequest);
-      return db.queryDryer(hpd);
+      let hpdRequest = request.query as ar.HeatPumpDryerRequest
+      return db.queryDryer(ar.toDryerQuery(hpdRequest));
     case "hphvac":
-      let hphvac = ar.setOptionalsForHvac(request.query as ar.HeatPumpHvacRequest);
-      return db.queryHvac(hphvac);
+      let hvacRequest = request.query as ar.HeatPumpHvacRequest
+      return db.queryHvac(ar.toHvacQuery(hvacRequest));
     default:
         return [];
   }

--- a/backend/src/dbutil.ts
+++ b/backend/src/dbutil.ts
@@ -1,37 +1,81 @@
 import * as dt from "../schema/appliance";
 import { HeatPumpWaterHeaterQuery, HeatPumpDryerQuery, HeatPumpHvacQuery} from "./model/appliance_query"
+import { convertUnit } from "./units";
 
 import fs = require("fs");
 import path from "path";
 
-const RAW_WATER_HEATERS: dt.HeatPumpWaterHeater[] = JSON.parse(fs.readFileSync(path.join(__dirname, "../data/water-heaters.json"), "utf-8"));
-const RAW_DRYERS: dt.HeatPumpDryer[] = JSON.parse(fs.readFileSync(path.join(__dirname, "../data/dryers.json"), "utf-8"));
-const RAW_HEATPUMPS: dt.HeatPump[] = JSON.parse(fs.readFileSync(path.join(__dirname, "../data/hvac.json"), "utf-8"));
-const RAW_STOVE: dt.Stove[] = JSON.parse(fs.readFileSync(path.join(__dirname, "../data/stove.json"), "utf-8"));
+interface IndexedArray<VALUE> {
+    [key: string]: VALUE;
+ }
+ 
+const DbDefaultUnits: IndexedArray<string> = {
+    'weight': 'kg',
+    'dimension': 'cm',
+};
+
+const RAW_WATER_HEATERS = JSON.parse(fs.readFileSync(path.join(__dirname, "../data/water-heaters.json"), "utf-8"));
+const RAW_DRYERS = JSON.parse(fs.readFileSync(path.join(__dirname, "../data/dryers.json"), "utf-8"));
+const RAW_HEATPUMPS = JSON.parse(fs.readFileSync(path.join(__dirname, "../data/hvac.json"), "utf-8"));
+const RAW_STOVE = JSON.parse(fs.readFileSync(path.join(__dirname, "../data/stove.json"), "utf-8"));
+
+const PROCEED_WATER_HEATERS = RAW_WATER_HEATERS.map(d => toQueryable(d)) as dt.HeatPumpWaterHeater[];
+const PROCEED_DRYERS = RAW_DRYERS.map(d => toQueryable(d)) as dt.HeatPumpDryer[];
+const PROCEED_HEATPUMPS = RAW_HEATPUMPS.map(d => toQueryable(d)) as dt.HeatPump[];
+const PROCEED_STOVE = RAW_STOVE.map(d => toQueryable(d)) as dt.Stove[];
+
+function toQueryable<Type extends dt.Appliance>(data: Type): Type {
+    data.weight.value = convertUnit(data.weight.value, data.weight.unit, DbDefaultUnits['weight']);
+    data.weight.unit = DbDefaultUnits['weight'];
+    return data;
+}
+
+function toViewUnits<Type extends dt.Appliance>(d: Type, dimensionUnit: string, weightUnit: string): Type {
+    d.dimensions.length = convertUnit(d.dimensions.length, d.dimensions.unit, dimensionUnit)
+    d.dimensions.width = convertUnit(d.dimensions.width, d.dimensions.unit , dimensionUnit)
+    d.dimensions.height = convertUnit(d.dimensions.height, d.dimensions.unit, dimensionUnit)
+    d.dimensions.unit = dimensionUnit;
+
+    d.weight.value = convertUnit(d.weight.value, d.weight.unit, weightUnit);
+    d.weight.unit = weightUnit;
+    return d;
+}
 
 export function queryWaterHeater(q: HeatPumpWaterHeaterQuery) {
-    return RAW_WATER_HEATERS.filter((heater) =>
-        heater.tankCapacityGallons >= q.tankCapacityMin &&
-        heater.tankCapacityGallons <= q.tankCapacityMax &&
-        heater.uniformEnergyFactor >= q.uniformEnergyFactor &&
-        heater.firstHourRating >= q.firstHourRating
-    );
+    return PROCEED_WATER_HEATERS
+            .filter((heater) =>
+                        heater.weight.value <= q.weight &&
+                        heater.electricBreakerSize <= q.electricBreakerSize &&
+                        heater.voltage <= q.voltage &&
+                        heater.tankCapacityGallons >= q.tankCapacityMin &&
+                        heater.tankCapacityGallons <= q.tankCapacityMax &&
+                        heater.uniformEnergyFactor >= q.uniformEnergyFactor &&
+                        heater.firstHourRating >= q.firstHourRating)
+            .map((data) => toViewUnits(data, q.dimensionUnit, q.weightUnit));
 }
 
 export function queryDryer(q: HeatPumpDryerQuery) {
-    return RAW_DRYERS.filter((dryer) =>
-        dryer.capacity >= q.capacityMin &&
-        dryer.capacity <= q.capacityMax &&
-        dryer.combinedEnergyFactor >= q.combinedEnergyFactor &&
-        dryer.soundLevelMax <= q.soundLevel
-    );
+    return PROCEED_DRYERS
+            .filter((dryer) =>
+                dryer.weight.value <= q.weight &&
+                dryer.electricBreakerSize <= q.electricBreakerSize &&
+                dryer.voltage <= q.voltage &&
+                dryer.capacity >= q.capacityMin &&
+                dryer.capacity <= q.capacityMax &&
+                dryer.combinedEnergyFactor >= q.combinedEnergyFactor &&
+                dryer.soundLevelMax <= q.soundLevel)
+            .map((data) => toViewUnits(data, q.dimensionUnit, q.weightUnit));
 }
 
 export function queryHvac(q: HeatPumpHvacQuery) {
-    return RAW_HEATPUMPS.filter((hp) =>
-        hp.tonnage >= q.tonnageMin &&
-        hp.tonnage <= q.tonnageMax
-    );
+    return PROCEED_HEATPUMPS
+            .filter((hp) =>
+                hp.weight.value <= q.weight &&
+                hp.electricBreakerSize <= q.electricBreakerSize &&
+                hp.voltage <= q.voltage &&
+                hp.tonnage >= q.tonnageMin &&
+                hp.tonnage <= q.tonnageMax)
+            .map((data) => toViewUnits(data, q.dimensionUnit, q.weightUnit));
 }
 
 export function allAppliances() {

--- a/backend/src/dbutil.ts
+++ b/backend/src/dbutil.ts
@@ -19,10 +19,10 @@ const RAW_DRYERS = JSON.parse(fs.readFileSync(path.join(__dirname, "../data/drye
 const RAW_HEATPUMPS = JSON.parse(fs.readFileSync(path.join(__dirname, "../data/hvac.json"), "utf-8"));
 const RAW_STOVE = JSON.parse(fs.readFileSync(path.join(__dirname, "../data/stove.json"), "utf-8"));
 
-const PROCEED_WATER_HEATERS = RAW_WATER_HEATERS.map(d => toQueryable(d)) as dt.HeatPumpWaterHeater[];
-const PROCEED_DRYERS = RAW_DRYERS.map(d => toQueryable(d)) as dt.HeatPumpDryer[];
-const PROCEED_HEATPUMPS = RAW_HEATPUMPS.map(d => toQueryable(d)) as dt.HeatPump[];
-const PROCEED_STOVE = RAW_STOVE.map(d => toQueryable(d)) as dt.Stove[];
+const PROCESSED_WATER_HEATERS = RAW_WATER_HEATERS.map(d => toQueryable(d)) as dt.HeatPumpWaterHeater[];
+const PROCESSED_DRYERS = RAW_DRYERS.map(d => toQueryable(d)) as dt.HeatPumpDryer[];
+const PROCESSED_HEATPUMPS = RAW_HEATPUMPS.map(d => toQueryable(d)) as dt.HeatPump[];
+const PROCESSED_STOVE = RAW_STOVE.map(d => toQueryable(d)) as dt.Stove[];
 
 function toQueryable<Type extends dt.Appliance>(data: Type): Type {
     data.weight.value = convertUnit(data.weight.value, data.weight.unit, DbDefaultUnits['weight']);
@@ -42,7 +42,7 @@ function toViewUnits<Type extends dt.Appliance>(d: Type, dimensionUnit: string, 
 }
 
 export function queryWaterHeater(q: HeatPumpWaterHeaterQuery) {
-    return PROCEED_WATER_HEATERS
+    return PROCESSED_WATER_HEATERS
             .filter((heater) =>
                         heater.weight.value <= q.weight &&
                         heater.electricBreakerSize <= q.electricBreakerSize &&
@@ -55,7 +55,7 @@ export function queryWaterHeater(q: HeatPumpWaterHeaterQuery) {
 }
 
 export function queryDryer(q: HeatPumpDryerQuery) {
-    return PROCEED_DRYERS
+    return PROCESSED_DRYERS
             .filter((dryer) =>
                 dryer.weight.value <= q.weight &&
                 dryer.electricBreakerSize <= q.electricBreakerSize &&
@@ -68,7 +68,7 @@ export function queryDryer(q: HeatPumpDryerQuery) {
 }
 
 export function queryHvac(q: HeatPumpHvacQuery) {
-    return PROCEED_HEATPUMPS
+    return PROCESSED_HEATPUMPS
             .filter((hp) =>
                 hp.weight.value <= q.weight &&
                 hp.electricBreakerSize <= q.electricBreakerSize &&

--- a/backend/src/model/appliance_query.ts
+++ b/backend/src/model/appliance_query.ts
@@ -1,5 +1,10 @@
 export interface ApplianceQuery {
     readonly applianceType: string;
+    weight: number;
+    weightUnit: string;
+    dimensionUnit: string;
+    electricBreakerSize: number;
+    voltage: number;
 };
 
 export interface HeatPumpWaterHeaterQuery extends ApplianceQuery {

--- a/backend/src/model/appliance_request.ts
+++ b/backend/src/model/appliance_request.ts
@@ -1,41 +1,55 @@
-import { HeatPumpWaterHeaterQuery, HeatPumpDryerQuery, HeatPumpHvacQuery} from "./appliance_query"
+import { convertUnit } from "../units";
+import { HeatPumpWaterHeaterQuery, HeatPumpDryerQuery, HeatPumpHvacQuery, ApplianceQuery } from "./appliance_query"
 import { RouteGenericInterface } from "fastify";
 
-export interface HeatPumpWaterHeaterRequest extends HeatPumpWaterHeaterQuery, RouteGenericInterface {}
-export interface HeatPumpDryerRequest extends HeatPumpDryerQuery, RouteGenericInterface {}
-export interface HeatPumpHvacRequest extends HeatPumpHvacQuery, RouteGenericInterface {}
+const defaultWeightUnit: string = 'lb';
+const defaultDimensionUnit: string = 'in';
+
+export interface HeatPumpWaterHeaterRequest extends HeatPumpWaterHeaterQuery, RouteGenericInterface {};
+export interface HeatPumpDryerRequest extends HeatPumpDryerQuery, RouteGenericInterface {};
+export interface HeatPumpHvacRequest extends HeatPumpHvacQuery, RouteGenericInterface {};
 
 export type ApplianceRequest = 
     HeatPumpWaterHeaterRequest | 
     HeatPumpDryerRequest | 
     HeatPumpHvacRequest; 
 
+function toApplianceQuery(r: ApplianceRequest): ApplianceQuery {
+    let w = r.weight ?? Number.MAX_VALUE;
+    let wu = r.weightUnit ?? defaultWeightUnit;
+    let du = r.dimensionUnit ?? defaultDimensionUnit;
 
-function setOptionalsForAppliance(r: ApplianceRequest) {
-    return r
+    return <ApplianceQuery> {
+        applianceType: r.applianceType,
+        weight: convertUnit(w, wu, 'kg'),
+        weightUnit: wu,
+        dimensionUnit: du,
+        electricBreakerSize: r.electricBreakerSize ?? Number.MAX_VALUE,
+        voltage: r.voltage ?? Number.MAX_VALUE,
+    };
 }
 
-export function setOptionalsForWaterHeater(r: HeatPumpWaterHeaterRequest) {
-    let r1 = setOptionalsForAppliance(r) as HeatPumpWaterHeaterQuery
-    r1.tankCapacityMin = r1.tankCapacityMin ?? 0;
-    r1.tankCapacityMax = r1.tankCapacityMax ?? Number.MAX_VALUE;
-    r1.firstHourRating = r1.firstHourRating ?? 0;
-    r1.uniformEnergyFactor = r1.uniformEnergyFactor ?? 0;
-    return r1
+export function toWaterHeaterQuery(r: HeatPumpWaterHeaterRequest) : HeatPumpWaterHeaterQuery {
+    let q = toApplianceQuery(r) as HeatPumpWaterHeaterQuery
+    q.tankCapacityMin = r.tankCapacityMin ?? 0;
+    q.tankCapacityMax = r.tankCapacityMax ?? Number.MAX_VALUE;
+    q.firstHourRating = r.firstHourRating ?? 0;
+    q.uniformEnergyFactor = r.uniformEnergyFactor ?? 0;
+    return q;
 }
 
-export function setOptionalsForDryer(r: HeatPumpDryerRequest) {
-    let r1 = setOptionalsForAppliance(r) as HeatPumpDryerQuery
-    r1.capacityMin = r1.capacityMin ?? 0;
-    r1.capacityMax = r1.capacityMax ?? Number.MAX_VALUE;
-    r1.soundLevel = r1.soundLevel ?? Number.MAX_VALUE;
-    r1.combinedEnergyFactor = r1.combinedEnergyFactor ?? 0;
-    return r1
+export function toDryerQuery(r: HeatPumpDryerRequest) : HeatPumpDryerQuery {
+    let q = toApplianceQuery(r) as HeatPumpDryerQuery
+    q.capacityMin = r.capacityMin ?? 0;
+    q.capacityMax = r.capacityMax ?? Number.MAX_VALUE;
+    q.soundLevel = r.soundLevel ?? Number.MAX_VALUE;
+    q.combinedEnergyFactor = r.combinedEnergyFactor ?? 0;
+    return q;
 }
 
-export function setOptionalsForHvac(r: HeatPumpHvacRequest) {
-    let r1 = setOptionalsForAppliance(r)as HeatPumpHvacQuery
-    r1.tonnageMin = r1.tonnageMin ?? 0;
-    r1.tonnageMax = r1.tonnageMax ?? Number.MAX_VALUE;
-    return r1
+export function toHvacQuery(r: HeatPumpHvacRequest): HeatPumpHvacQuery {
+    let q = toApplianceQuery(r) as HeatPumpHvacQuery
+    q.tonnageMin = r.tonnageMin ?? 0
+    q.tonnageMax = r.tonnageMax ?? Number.MAX_VALUE;
+    return q;
 }

--- a/backend/src/units.ts
+++ b/backend/src/units.ts
@@ -1,0 +1,11 @@
+import configureMeasurements from 'convert-units';
+import allMeasures, {AllMeasuresUnits} from 'convert-units/definitions/all';
+
+const convert = configureMeasurements(allMeasures);
+
+export function convertUnit(val: number, fromUnit: string, toUnit: string): number {
+    if (val == Number.MAX_VALUE || fromUnit == toUnit) {
+        return val;
+    }
+    return convert(val).from(fromUnit as AllMeasuresUnits).to(toUnit as AllMeasuresUnits);
+}


### PR DESCRIPTION
Prototype for supporting multiple weight and dimension units as different spec may include different units and we would like to store the data as it is instead of storing data with unit conversions.

A subsequent change in the backend is required to convert the raw units into standardised unit i.e. in Kg and cm upon startup and load all the processed data in memory. This prevents converting unit conversion on the entire data store for each incoming GET request.