### PR TITLE
Use select filter instead of input.

### DIFF
--- a/frontend/app/components/appliances-forms/HeatPumpDryer.tsx
+++ b/frontend/app/components/appliances-forms/HeatPumpDryer.tsx
@@ -5,7 +5,6 @@ import "./tabulator-modern-custom.css";
 // import "react-tabulator/lib/styles.css";
 import { ReactTabulator, ColumnDefinition } from "react-tabulator";
 import { getUnique } from "./HeatPumpWaterHeaterForm";
-import { HeatPumpDryer as HeatPumpDryerType } from "../../../../backend/schema/heat_pump_dryer";
 
 const HeatPumpDryer = () => {
   const [showResults, setShowResults] = useState(false);
@@ -45,7 +44,7 @@ const HeatPumpDryer = () => {
   //   setResults(data);
   //   setShowResults(true);
   // };
-  const [results, setResults] = useState<HeatPumpDryerType[]>([]);
+  const [results, setResults] = useState<any[]>([]);
 
   const fetchData = async () => {
     const apiUrl = `https://electric-machines-h6x1.vercel.app/api/v1/appliance?applianceType=hpd&soundLevel=100&cef=1.0&capacityMin=1.0&capacityMax=100`;

--- a/frontend/app/components/appliances-forms/HeatPumpDryer.tsx
+++ b/frontend/app/components/appliances-forms/HeatPumpDryer.tsx
@@ -5,7 +5,7 @@ import "./tabulator-modern-custom.css";
 // import "react-tabulator/lib/styles.css";
 import { ReactTabulator, ColumnDefinition } from "react-tabulator";
 import { getUnique } from "./HeatPumpWaterHeaterForm";
-import { HeatPumpDryer } from "../../../../backend/schema/heat_pump_dryer";
+import { HeatPumpDryer as HeatPumpDryerType } from "../../../../backend/schema/heat_pump_dryer";
 
 const HeatPumpDryer = () => {
   const [showResults, setShowResults] = useState(false);
@@ -45,7 +45,7 @@ const HeatPumpDryer = () => {
   //   setResults(data);
   //   setShowResults(true);
   // };
-  const [results, setResults] = useState<HeatPumpDryer[]>([]);
+  const [results, setResults] = useState<HeatPumpDryerType[]>([]);
 
   const fetchData = async () => {
     const apiUrl = `https://electric-machines-h6x1.vercel.app/api/v1/appliance?applianceType=hpd&soundLevel=100&cef=1.0&capacityMin=1.0&capacityMax=100`;

--- a/frontend/app/components/appliances-forms/HeatPumpDryer.tsx
+++ b/frontend/app/components/appliances-forms/HeatPumpDryer.tsx
@@ -4,6 +4,8 @@ import { useState, useMemo, useEffect } from "react";
 import "./tabulator-modern-custom.css";
 // import "react-tabulator/lib/styles.css";
 import { ReactTabulator, ColumnDefinition } from "react-tabulator";
+import { getUnique } from "./HeatPumpWaterHeaterForm";
+import { HeatPumpDryer } from "../../../../backend/schema/heat_pump_dryer";
 
 const HeatPumpDryer = () => {
   const [showResults, setShowResults] = useState(false);
@@ -43,7 +45,7 @@ const HeatPumpDryer = () => {
   //   setResults(data);
   //   setShowResults(true);
   // };
-  const [results, setResults] = useState([]);
+  const [results, setResults] = useState<HeatPumpDryer[]>([]);
 
   const fetchData = async () => {
     const apiUrl = `https://electric-machines-h6x1.vercel.app/api/v1/appliance?applianceType=hpd&soundLevel=100&cef=1.0&capacityMin=1.0&capacityMax=100`;
@@ -61,16 +63,28 @@ const HeatPumpDryer = () => {
       title: "Brand",
       field: "brandName",
       minWidth: 165,
-      headerFilter: "input",
-      headerFilterPlaceholder: "Brand (e.g., Rheem)",
+      headerFilter: "select",
+      headerFilterFunc: "in",
+      headerFilterParams: {
+        values: getUnique(results.map((appliance) => appliance.brandName)),
+        sortValuesList: "asc",
+        multiselect: true,
+      },
+      headerFilterPlaceholder: "Filter: All",
     },
     {
       title: "Model",
       field: "modelNumber",
       hozAlign: "left",
       minWidth: 200,
-      headerFilter: "input",
-      headerFilterPlaceholder: "Model (e.g., RH375)",
+      headerFilter: "select",
+      headerFilterFunc: "in",
+      headerFilterParams: {
+        values: getUnique(results.map((appliance) => appliance.modelNumber)),
+        sortValuesList: "asc",
+        multiselect: true,
+      },
+      headerFilterPlaceholder: "Filter: All",
     },
     {
       title: "Capacity (cu-ft)",
@@ -79,7 +93,7 @@ const HeatPumpDryer = () => {
       minWidth: 160,
       headerFilter: "input",
       headerFilterFunc: ">=",
-      headerFilterPlaceholder: "Minimum (e.g., 3.0)",
+      headerFilterPlaceholder: "Minimum: not set",
       headerTooltip:
         "Capacity refers to the volume of clothes the dryer can hold and dry efficiently, usually measured in cubic feet. A larger capacity is ideal for big households or doing less frequent, larger loads.",
     },
@@ -90,7 +104,7 @@ const HeatPumpDryer = () => {
       minWidth: 150,
       headerFilter: "input",
       headerFilterFunc: ">=",
-      headerFilterPlaceholder: "Mininum (e.g., 1.0)",
+      headerFilterPlaceholder: "Minimum: not set",
       headerTooltip:
         "A higher CEF means better energy efficiency, leading to lower operating costs over time. Consider this factor for long-term savings.",
     },
@@ -101,7 +115,7 @@ const HeatPumpDryer = () => {
       minWidth: 150,
       headerFilter: "input",
       headerFilterFunc: "<=",
-      headerFilterPlaceholder: "Maximum (e.g., 65)",
+      headerFilterPlaceholder: "Maximum (not set)",
       headerTooltip:
         "<60 dB: Very quiet, ideal for living areas. 60-65 dB: Noticeable, not too loud, common for dryers. >65 dB: Loud, like a vacuum, might be disruptive.",
     },
@@ -110,6 +124,30 @@ const HeatPumpDryer = () => {
       field: "voltage",
       hozAlign: "center",
       minWidth: 140,
+      headerFilter: "select",
+      headerFilterFunc: "in",
+      headerFilterParams: {
+        values: getUnique(results.map((appliance) => appliance.voltage)),
+        sortValuesList: "asc",
+        multiselect: true,
+      },
+      headerFilterPlaceholder: "Filter: All",
+    },
+    {
+      title: "Breaker Size",
+      field: "electricBreakerSize",
+      hozAlign: "center",
+      minWidth: 150,
+      headerFilter: "select",
+      headerFilterFunc: "in",
+      headerFilterParams: {
+        values: getUnique(
+          results.map((appliance) => appliance.electricBreakerSize)
+        ),
+        sortValuesList: "asc",
+        multiselect: true,
+      },
+      headerFilterPlaceholder: "Filter: All",
     },
     {
       title: "Weight (kg)",
@@ -133,12 +171,6 @@ const HeatPumpDryer = () => {
     {
       title: "Length (cm)",
       field: "lengthInCm",
-      hozAlign: "center",
-      minWidth: 150,
-    },
-    {
-      title: "Breaker Size",
-      field: "electricBreakerSize",
       hozAlign: "center",
       minWidth: 150,
     },

--- a/frontend/app/components/appliances-forms/HeatPumpWaterHeaterForm.tsx
+++ b/frontend/app/components/appliances-forms/HeatPumpWaterHeaterForm.tsx
@@ -4,7 +4,6 @@ import styles from "./sharedForms.module.scss";
 import { useState, useMemo, useEffect } from "react";
 import TableContainer from "../TableContainer";
 import { ReactTabulator, ColumnDefinition } from "react-tabulator";
-import { HeatPumpWaterHeater } from "../../../../backend/schema/appliance";
 
 export function getUnique(values: any[]): any[] {
   return values.filter((val, ind) => {
@@ -14,7 +13,7 @@ export function getUnique(values: any[]): any[] {
 
 const HeatPumpWaterHeaterForm = () => {
   const [showResults, setShowResults] = useState(false);
-  const [results, setResults] = useState<HeatPumpWaterHeater[]>([]);
+  const [results, setResults] = useState<any[]>([]);
 
   //default values
   const [tankCapacityGallons, setTankCapacityGallons] = useState("30");

--- a/frontend/app/components/appliances-forms/HeatPumpWaterHeaterForm.tsx
+++ b/frontend/app/components/appliances-forms/HeatPumpWaterHeaterForm.tsx
@@ -4,10 +4,17 @@ import styles from "./sharedForms.module.scss";
 import { useState, useMemo, useEffect } from "react";
 import TableContainer from "../TableContainer";
 import { ReactTabulator, ColumnDefinition } from "react-tabulator";
+import { HeatPumpWaterHeater } from "../../../../backend/schema/appliance";
+
+export function getUnique(values: any[]): any[] {
+  return values.filter((val, ind) => {
+    return values.indexOf(val) === ind;
+  });
+}
 
 const HeatPumpWaterHeaterForm = () => {
   const [showResults, setShowResults] = useState(false);
-  const [results, setResults] = useState([]);
+  const [results, setResults] = useState<HeatPumpWaterHeater[]>([]);
 
   //default values
   const [tankCapacityGallons, setTankCapacityGallons] = useState("30");
@@ -64,25 +71,42 @@ const HeatPumpWaterHeaterForm = () => {
       title: "Brand",
       field: "brandName",
       minWidth: 165,
-      headerFilter: "input",
-      headerFilterPlaceholder: "Brand (e.g., Rheem)",
+      headerFilter: "select",
+      headerFilterFunc: "in",
+      headerFilterParams: {
+        values: getUnique(results.map((appliance) => appliance.brandName)),
+        sortValuesList: "asc",
+        multiselect: true,
+      },
+      headerFilterPlaceholder: "Filter: All",
     },
     {
       title: "Model",
       field: "modelNumber",
       hozAlign: "left",
       minWidth: 200,
-      headerFilter: "input",
-      headerFilterPlaceholder: "Model (e.g., RH375)",
+      headerFilter: "select",
+      headerFilterFunc: "in",
+      headerFilterParams: {
+        values: getUnique(results.map((appliance) => appliance.modelNumber)),
+        multiselect: true,
+      },
+      headerFilterPlaceholder: "Filter: All",
     },
     {
       title: "Capacity (gallons)",
       field: "tankCapacityGallons",
       hozAlign: "center",
       minWidth: 160,
-      headerFilter: "input",
-      headerFilterFunc: ">=",
-      headerFilterPlaceholder: "Minimum (e.g., 40)",
+      headerFilter: "select",
+      headerFilterFunc: "in",
+      headerFilterParams: {
+        values: getUnique(
+          results.map((appliance) => appliance.tankCapacityGallons)
+        ),
+        multiselect: true,
+      },
+      headerFilterPlaceholder: "Filter: All",
       headerTooltip:
         "Choose based upon your household's hot water usage. 1-2 people: 30-40 gallons, 3-4 people: 50-60 gallons, 5-6 people: 65-80 gallons, 7+ people: 80+ gallons.",
     },
@@ -94,7 +118,7 @@ const HeatPumpWaterHeaterForm = () => {
       minWidth: 150,
       headerFilter: "input",
       headerFilterFunc: ">=",
-      headerFilterPlaceholder: "Mininum (e.g., 3.0)",
+      headerFilterPlaceholder: "Mininum: not set",
       headerTooltip:
         "Measures overall energy efficiency, influencing long-term energy costs.",
     },
@@ -105,7 +129,7 @@ const HeatPumpWaterHeaterForm = () => {
       minWidth: 150,
       headerFilter: "input",
       headerFilterFunc: ">=",
-      headerFilterPlaceholder: "Minimum (e.g., 40)",
+      headerFilterPlaceholder: "Minimum: not set",
       headerTooltip:
         "Estimates hot water supply in the first hour, crucial for peak demand.",
     },
@@ -114,6 +138,28 @@ const HeatPumpWaterHeaterForm = () => {
       field: "voltage",
       hozAlign: "center",
       minWidth: 140,
+      headerFilter: "select",
+      headerFilterFunc: "in",
+      headerFilterParams: {
+        values: getUnique(results.map((appliance) => appliance.voltage)),
+        multiselect: true,
+      },
+      headerFilterPlaceholder: "Filter: All",
+    },
+    {
+      title: "Breaker Size",
+      field: "electricBreakerSize",
+      hozAlign: "center",
+      minWidth: 150,
+      headerFilter: "select",
+      headerFilterFunc: "in",
+      headerFilterParams: {
+        values: getUnique(
+          results.map((appliance) => appliance.electricBreakerSize)
+        ),
+        multiselect: true,
+      },
+      headerFilterPlaceholder: "Filter: All",
     },
     {
       title: "Weight (kg)",
@@ -137,12 +183,6 @@ const HeatPumpWaterHeaterForm = () => {
     {
       title: "Length (cm)",
       field: "lengthInCm",
-      hozAlign: "center",
-      minWidth: 150,
-    },
-    {
-      title: "Breaker Size",
-      field: "electricBreakerSize",
       hozAlign: "center",
       minWidth: 150,
     },


### PR DESCRIPTION
I figured out how to use the 'select' filter type, which I think is a better experience compared to straight input for some of the columns. I also:

1. tweaked the placeholder text since in context I think it makes it clearer that you're supposed to edit those filters
2. switched the order of some of the columns so voltage and breaker size were next to each other, and made those filterable as well

Follow-ups:
1. It would be nice to replace those `any[]` types with `HeatPumpWaterHeater[]` and `HeatPumpDryer[]` since we'd get type safety. That what I had originally. However, this caused Vercel to fail because of the import from the backend. I'm not sure why.
2. I believe that setting `values: true` in the header filter params should cause tabulator to show all of the possible values, but for some reason, I get no values instead, hence the getUnique method. It would be nice to replace this at some point.