### PR TITLE
Remove applianceType from the final record.

### DIFF
--- a/pipeline/src/validate_data.ts
+++ b/pipeline/src/validate_data.ts
@@ -108,7 +108,7 @@ async function main() {
         }
 
         const metadata = await retrieveMetadata(applianceFolder);
-        const columnsToCopy = ["applianceType", "brandName", "sourceUrl"];
+        const columnsToCopy = ["brandName", "sourceUrl"];
         const metadataToCopy = _.pick(metadata, columnsToCopy);
 
         const specs = Array.isArray(filtered["data"])
@@ -131,6 +131,7 @@ async function main() {
           }
           let spreadsheetRecord = {
             valid: validate(augmentedSpec) ? "true" : "false",
+            applianceType: metadata.applianceType,
             ...augmentedSpec,
           };
           const matchingRecord = findMatchingInput(


### PR DESCRIPTION
We want applianceType in the spreadsheet for human review, but it is causing schema validation errors to have it copied into the appliances since we don't accept additional properties.