### PR TITLE
Add correction stage, combine tables together, implement retries.

### DIFF
--- a/pipeline/src/correct_data.ts
+++ b/pipeline/src/correct_data.ts
@@ -1,0 +1,180 @@
+import { program } from "commander";
+
+import fs = require("node:fs/promises");
+import path = require("node:path");
+
+import {
+  renderMissingDataPrompt,
+  MISSING_EXAMPLE_1_INPUT,
+  MISSING_EXAMPLE_1_OUTPUT,
+} from "./prompts";
+
+import { GptWrapper } from "./gpt_wrapper";
+import { glob } from "glob";
+import { APPLIANCE_TYPES } from "../../backend/schema/metadata";
+import {
+  HEAT_PUMP_DRYER_METADATA,
+  HEAT_PUMP_METADATA,
+  HEAT_PUMP_WATER_HEATER_METADATA,
+  SpecsMetadata,
+} from "./schemas";
+import { ModelGeneratedAppliance } from "../../backend/schema/appliance";
+import { retrieveMetadata } from "./metadata";
+
+const SPECS_FILE_BASE = "../data/";
+const INPUT_SUBDIR = "renamed/";
+const OUTPUT_SUBDIR = "corrected/";
+const RUNS = "runs/";
+const MODEL_FAMILY = "gpt"; // eventually support more options
+
+program
+  .requiredOption(
+    "-f, --folders <folders...>",
+    "Name of folder(s) under incentives_data/ where text data is located."
+  )
+  .option(
+    "-w, --wait <duration_ms>",
+    "How long to wait in ms between requests to avoid rate limiting"
+  );
+
+program.parse();
+
+async function main() {
+  const opts = program.opts();
+
+  const allPromises: Promise<void>[] = [];
+  const droppedFiles: string[] = [];
+  for (const topFolder of opts.folders) {
+    const folders = await glob(
+      path.join(SPECS_FILE_BASE, topFolder, "**", INPUT_SUBDIR),
+      { ignore: path.join(SPECS_FILE_BASE, RUNS) }
+    );
+    for (const inputFolder of folders) {
+      const applianceFolder = path.dirname(inputFolder);
+      const outputFolder = path.join(applianceFolder, OUTPUT_SUBDIR);
+      await fs.mkdir(outputFolder, { recursive: true });
+      const folderPromises: Promise<void>[] = [];
+      for (const file of await fs.readdir(inputFolder)) {
+        const filteredFilePath = path.join(inputFolder, file);
+        if (!file.endsWith("reformatted.json")) continue;
+        const applianceRecords = JSON.parse(
+          await fs.readFile(filteredFilePath, {
+            encoding: "utf8",
+          })
+        );
+
+        if (applianceRecords.length == 0) {
+          console.log(`Skipping ${filteredFilePath} because it is empty`);
+          continue;
+        }
+
+        if (opts.wait) {
+          await new Promise((f) => setTimeout(f, +opts.wait));
+        }
+
+        const metadata = await retrieveMetadata(applianceFolder);
+        if (!("applianceType" in metadata)) {
+          throw new Error("applianceType not set in metadata");
+        }
+
+        const textFilePath = path.join(applianceFolder, "raw.txt");
+        const txt = await fs.readFile(textFilePath, { encoding: "utf-8" });
+        const applianceType = metadata.applianceType;
+
+        let modelMetadata: SpecsMetadata<ModelGeneratedAppliance>;
+        if (applianceType === APPLIANCE_TYPES.heat_pump) {
+          modelMetadata = HEAT_PUMP_METADATA;
+        } else if (applianceType === APPLIANCE_TYPES.heat_pump_water_heater) {
+          modelMetadata = HEAT_PUMP_WATER_HEATER_METADATA;
+        } else if (applianceType === APPLIANCE_TYPES.heat_pump_dryer) {
+          modelMetadata = HEAT_PUMP_DRYER_METADATA;
+        } else {
+          throw new Error(
+            "No model metadata configured for this appliance type"
+          );
+        }
+        const missingFields: Set<string> = new Set();
+        for (const field of Object.keys(modelMetadata)) {
+          for (const record of applianceRecords["data"]) {
+            if (!(field in record)) {
+              missingFields.add(field);
+            }
+          }
+        }
+        const relevantMetadata = Object.fromEntries(
+          Object.entries(modelMetadata).filter(([key]) =>
+            missingFields.has(key)
+          )
+        );
+
+        console.log(`Querying ${MODEL_FAMILY} with ${filteredFilePath}`);
+        const gpt_wrapper = new GptWrapper(MODEL_FAMILY);
+        const queryFunc = gpt_wrapper.queryGpt.bind(gpt_wrapper);
+        const promise = queryFunc(
+          JSON.stringify(applianceRecords),
+          renderMissingDataPrompt(relevantMetadata),
+          [[MISSING_EXAMPLE_1_INPUT, MISSING_EXAMPLE_1_OUTPUT]]
+        ).then(async (msg: string) => {
+          if (msg == "") return;
+          console.log(`Got response from ${filteredFilePath}`);
+          try {
+            let response = JSON.parse(msg);
+            await fs.writeFile(
+              path.join(outputFolder, "raw_response.json"),
+              JSON.stringify(response, null, 2),
+              {
+                encoding: "utf-8",
+                flag: "w",
+              }
+            );
+
+            // Iterate through
+            if (
+              Symbol.iterator in Object(response) &&
+              Symbol.iterator in Object(applianceRecords["data"])
+            ) {
+              for (const record of applianceRecords["data"]) {
+                for (const resp of response) {
+                  if (record.modelNumber === resp.modelNumber) {
+                    for (const prop in resp) {
+                      if (prop in record || resp[prop] === null) {
+                        continue;
+                      }
+                      record[prop] = resp[prop];
+                    }
+                  }
+                }
+              }
+            }
+            await fs.writeFile(
+              path.join(outputFolder, "output.json"),
+              JSON.stringify(applianceRecords, null, 2),
+              {
+                encoding: "utf-8",
+                flag: "w",
+              }
+            );
+          } catch (error) {
+            console.error(`Error parsing json: ${error}, ${msg}`);
+            droppedFiles.push(filteredFilePath);
+          }
+        });
+        allPromises.push(promise);
+        folderPromises.push(promise);
+      }
+    }
+  }
+  await Promise.allSettled(allPromises).then(async () => {
+    const ts = Date.now();
+    const summaryDir = path.join(SPECS_FILE_BASE, RUNS, ts.toString());
+    await fs.mkdir(summaryDir, { recursive: true });
+    if (droppedFiles.length > 0) {
+      await fs.writeFile(
+        path.join(summaryDir, "dropped_files.json"),
+        JSON.stringify(droppedFiles)
+      );
+    }
+  });
+}
+
+main();

--- a/pipeline/src/correct_data.ts
+++ b/pipeline/src/correct_data.ts
@@ -56,7 +56,7 @@ async function main() {
       const folderPromises: Promise<void>[] = [];
       for (const file of await fs.readdir(inputFolder)) {
         const filteredFilePath = path.join(inputFolder, file);
-        if (!file.endsWith("reformatted.json")) continue;
+        if (!file.endsWith("records.json")) continue;
         const applianceRecords = JSON.parse(
           await fs.readFile(filteredFilePath, {
             encoding: "utf8",
@@ -147,7 +147,7 @@ async function main() {
               }
             }
             await fs.writeFile(
-              path.join(outputFolder, "output.json"),
+              path.join(outputFolder, "records.json"),
               JSON.stringify(applianceRecords, null, 2),
               {
                 encoding: "utf-8",

--- a/pipeline/src/gpt_wrapper.ts
+++ b/pipeline/src/gpt_wrapper.ts
@@ -61,12 +61,24 @@ export class GptWrapper {
       });
       return completion.choices[0].message!.content!;
     } catch (error) {
-      if (error instanceof Error) {
-        console.error(`Error with OpenAI API request: ${error.message}`);
+      if (
+        error instanceof Error &&
+        error.message.includes("This model's maximum context length is") &&
+        model !== "gpt-4-1106-preview"
+      ) {
+        console.log(
+          "Retrying request with gpt-4-1106-preview model with larger context window"
+        );
+        const retry = await openai.chat.completions.create({
+          model: "gpt-4-0125-preview",
+          messages: messages,
+          temperature: 0.0,
+          seed: 0,
+        });
+        return retry.choices[0].message!.content!;
       } else {
-        console.error(`Error with OpenAI API request: ${error}`);
+        throw error;
       }
     }
-    return "";
   }
 }

--- a/pipeline/src/prompts.ts
+++ b/pipeline/src/prompts.ts
@@ -35,30 +35,6 @@ If there are numeric row/column numbers in the tables, you can ignore them.
 Please send the response in plain text without code formatting.
 `;
 
-export function renderSystemPrompt<T>(metadata: SpecsMetadata<T>) {
-  const system: string = `You are a helpful assistant.
-  
-You will be given JSON input that contains technical specifications for
-appliances such as heat pumps or clothes dryers. Each record describes one
-appliance. Your task is to fit that data to the schema below and return one
-transformed record per original record.
-
-Do not return null values. Ultimately, if you can't find a good fit for a field,
-it's okay to leave it blank.
-
-Put all converted records in an array, with the JSON key called "data".
-
-You should also output the mapping you construct from column names
-in the input to the fields in the schema. Only give the mapping for fields that
-you use. The key for this output should be "mapping".
-
-If the table is empty of any meaningful data, you can return an empty object for
-the data and mapping keys.
-
-${renderSchemaGuide(metadata)}`;
-  return system;
-}
-
 export const REFORMAT_EXAMPLE_1_INPUT: string = `[[{"0":{"0":"Physical Data","1":"Model No.#","2":"Nominal Tonnage","3":"Valve Connections","4":"Compressor Type","5":"watts","6":"Shipping weight \\u2013 lbs.","7":"Operating  weight \\u2013 lbs."},
 "1":{"0":"","1":"RP1418","2":"1.5","3":"","4":"Scroll","5":"151","6":"159","7":"152"},
 "2":{"0":"","1":"RP1424","2":"2.0","3":"","4":"","5":"156","6":"152","7":"145"},
@@ -101,6 +77,30 @@ export const REFORMAT_EXAMPLE_1_OUTPUT: string = `[
   }
 ]`;
 
+export function renderSystemPrompt<T>(metadata: SpecsMetadata<T>) {
+  const system: string = `You are a helpful assistant.
+  
+You will be given JSON input that contains technical specifications for
+appliances such as heat pumps or clothes dryers. Each record describes one
+appliance. Your task is to fit that data to the schema below and return one
+transformed record per original record.
+
+Do not return null values. Ultimately, if you can't find a good fit for a field,
+it's okay to leave it blank.
+
+Put all converted records in an array, with the JSON key called "data".
+
+You should also output the mapping you construct from column names
+in the input to the fields in the schema. Only give the mapping for fields that
+you use. The key for this output should be "mapping".
+
+If the table is empty of any meaningful data, you can return an empty object for
+the data and mapping keys.
+
+${renderSchemaGuide(metadata)}`;
+  return system;
+}
+
 export const MAPPING_EXAMPLE_1_INPUT: string = `[
   {
     "modelNumber": "RP1418",
@@ -127,37 +127,132 @@ export const MAPPING_EXAMPLE_1_INPUT: string = `[
 ]`;
 
 export const MAPPING_EXAMPLE_1_OUTPUT: string = `{
-  "data": {
-    [
-      {
-        "modelNumber": "RP1418",
-        "tonnage": 1.5,
-        "weight": {
-          "value": 152,
-          "unit": "kg"
-        }
-      },
-      {
-        "modelNumber": "RP1424",
-        "tonnage": 2.0,
-        "weight": {
-          "value": 145,
-          "unit": "kg"
-        }
-      },
-      {
-        "modelNumber": "RP1430",
-        "tonnage": 2.5,
-        "weight": {
-          "value": 201,
-          "unit": "kg"
-        }
+  "data": [
+    {
+      "modelNumber": "RP1418",
+      "tonnage": 1.5,
+      "weight": {
+        "value": 152,
+        "unit": "kg"
       }
-    ]
-  },
+    },
+    {
+      "modelNumber": "RP1424",
+      "tonnage": 2.0,
+      "weight": {
+        "value": 145,
+        "unit": "kg"
+      }
+    },
+    {
+      "modelNumber": "RP1430",
+      "tonnage": 2.5,
+      "weight": {
+        "value": 201,
+        "unit": "kg"
+      }
+    }
+  ],
   "mapping": {
     "modelNumber": "modelNumber",
     "Nominal Tonnage": "tonnage",
     "Operating weight \\u2013 kg.": "weight"
   }
 }`;
+
+export function renderMissingDataPrompt(metadata: {
+  [index: string]: FieldMetadata;
+}) {
+  const system: string = `You are a helpful assistant.
+  
+You will be given JSON input that contains technical specifications for
+appliances such as heat pumps or clothes dryers. Each record describes one
+appliance. The data is currently missing some fields. You'll also be given
+the text of the PDF where the JSON data came from, and asked to fill in the
+missing fields if you can find them. The PDF text might be somewhat messy and
+include tables rendered as text.
+
+Return your results in JSON format, with one record per original record. Include
+the modelNumber key and then any new properties that you find. Do not include original
+properties except for the modelNumber.
+
+Ultimately, if you can't find a good fit for a field, it's okay to leave it blank.
+Don't return null values; simply don't include the key for that field.
+
+${renderSchemaGuide(metadata)}`;
+  return system;
+}
+
+const missingExample1Text = `        RP14 Series
+
+All models are 240 volts.
+
+Physical Data                                            RP1418  RP1424  RP1430
+                                                           1.5     2.0     2.5
+  Model No
+  Nominal Tonnage                                          3/8     3/8     3/8
+  Valve Connections                                        3/4     3/4     3/4
+                                                           123      89     106
+                               Liquid Line O.D. - in.                             
+                             Suction Line O.D. - in.      11.14    9.1     11.1
+  Refrigerant (R410A) furnished oz.�                        --      --      --
+  Compressor Type                                          3/8     3/8     3/8
+                              watts                        151     156     142
+                 Shipping weight - lbs.                    159     152     208
+                 Operating weight - lbs.                   152     145     201
+
+Other Data                                          
+Sound Level (decibels)                                     65      68      72
+Minimum Breaker Size                                       15      30      50
+`;
+
+export const MISSING_EXAMPLE_1_INPUT = `{
+  "missingFields": ["voltage", "electricBreakerSize"],
+  "records": [
+    {
+      "modelNumber": "RP1418",
+      "weight": {
+        "value": 159,
+        "unit": "lb"
+      },
+      "soundLevelMin": 65,
+      "soundLevelMax": 65
+    },
+    {
+      "modelNumber": "RP1424",
+      "weight": {
+        "value": 159,
+        "unit": "lb"
+      },
+      "soundLevelMin": 65,
+      "soundLevelMax": 65
+    },
+    {
+      "modelNumber": "RP1430",
+      "weight": {
+        "value": 159,
+        "unit": "lb"
+      },
+      "soundLevelMin": 65,
+      "soundLevelMax": 65
+    }
+  ],
+  "text": "${missingExample1Text}"
+}`;
+export const MISSING_EXAMPLE_1_OUTPUT = `[
+  {
+    "modelNumber": "RP1418",
+    "voltage": 240,
+    "electricBreakerSize": 15
+  },
+  {
+    "modelNumber": "RP1424",
+    "voltage": 240,
+    "electricBreakerSize": 30
+  },
+  {
+    "modelNumber": "RP1430",
+    "voltage": 240,
+    "electricBreakerSize": 50
+  }
+]`;

--- a/pipeline/src/prompts.ts
+++ b/pipeline/src/prompts.ts
@@ -13,20 +13,26 @@ export function renderSchemaGuide(specs: {
 
 export const TABLE_REFORMAT_PROMPT = `You are a helpful assistant.
   
-You will be given the output of a table that was read from a PDF and converted
+You will be given a series of tables that were read from a PDF and converted
 to JSON. The tables contain technical specifications about appliances, with possibly
 more than one appliance in the tables. Your task is to reformat the tables into
-valid JSON with one key-value record per model. Return an array even if there is only
+valid JSON with one key-value record per appliance model. Return an array even if there is only
 one record.
 
 The only required field is modelNumber. Even if you don't see a column with that name,
 try to find a similarly named column and use that. Otherwise, use the column names in the
 PDF. You can omit columns that don't have any data in them.
 
-If the table is empty of any meaningful data or does not contain any model numbers,
+Some tables may not have a model number, but if they follow a table that does, it's possible
+that table is a continuation of the previous table, and if it has the same
+number of columns as the previous table, you can use the same model numbers.
+
+If a table is empty of any meaningful data or does not contain any model numbers,
 you can return an empty object.
 
-If there are numeric row/column numbers in the table, you can ignore them.
+If there are numeric row/column numbers in the tables, you can ignore them.
+
+Please send the response in plain text without code formatting.
 `;
 
 export function renderSystemPrompt<T>(metadata: SpecsMetadata<T>) {
@@ -53,10 +59,15 @@ ${renderSchemaGuide(metadata)}`;
   return system;
 }
 
-export const REFORMAT_EXAMPLE_1_INPUT: string = `{"0":{"0":"Physical Data","1":"Model No.#","2":"Nominal Tonnage","3":"Valve Connections","4":"Compressor Type","5":"watts","6":"Shipping weight \\u2013 lbs.","7":"Operating  weight \\u2013 lbs."},
+export const REFORMAT_EXAMPLE_1_INPUT: string = `[[{"0":{"0":"Physical Data","1":"Model No.#","2":"Nominal Tonnage","3":"Valve Connections","4":"Compressor Type","5":"watts","6":"Shipping weight \\u2013 lbs.","7":"Operating  weight \\u2013 lbs."},
 "1":{"0":"","1":"RP1418","2":"1.5","3":"","4":"Scroll","5":"151","6":"159","7":"152"},
 "2":{"0":"","1":"RP1424","2":"2.0","3":"","4":"","5":"156","6":"152","7":"145"},
-"3":{"0":"","1":"RP1430","2":"2.5","3":"","4":"","5":"142","6":"208","7":"201"}}
+"3":{"0":"","1":"RP1430","2":"2.5","3":"","4":"","5":"142","6":"208","7":"201"}}],
+[{"0":{"0":"Other Data","1":"Sound Level (decibels)","2":"Minimum Breaker Size"},
+"1":{"0":"","1":"65","2":"15"},
+"2":{"0":"","1":"68","2":"30"},
+"3":{"0":"","1":"72","2":"30"}}]
+]
 `;
 
 export const REFORMAT_EXAMPLE_1_OUTPUT: string = `[
@@ -66,21 +77,27 @@ export const REFORMAT_EXAMPLE_1_OUTPUT: string = `[
     "Compressor Type": "Scroll",
     "watts": 151,
     "Shipping weight \\u2013 lbs.": 159,
-    "Operating  weight \\u2013 lbs.": 152
+    "Operating  weight \\u2013 lbs.": 152,
+    "Sound Level (decibels)": 65,
+    "Minimum Breaker Size": 15
   },
   {
     "modelNumber": "RP1424",
     "Nominal Tonnage": 2.0,
     "watts": 156,
     "Shipping weight \\u2013 lbs.": 152,
-    "Operating  weight \\u2013 lbs.": 145
+    "Operating  weight \\u2013 lbs.": 145,
+    "Sound Level (decibels)": 68,
+    "Minimum Breaker Size": 30
   },
   {
     "modelNumber": "RP1430",
     "Nominal Tonnage": 2.5,
     "watts": 142,
     "Shipping weight \\u2013 lbs.": 208,
-    "Operating  weight \\u2013 lbs.": 201
+    "Operating  weight \\u2013 lbs.": 201,
+    "Sound Level (decibels)": 72,
+    "Minimum Breaker Size": 30
   }
 ]`;
 

--- a/pipeline/src/reformat_tables.ts
+++ b/pipeline/src/reformat_tables.ts
@@ -4,7 +4,6 @@ import fs = require("node:fs/promises");
 import path = require("node:path");
 
 import {
-  renderSystemPrompt,
   REFORMAT_EXAMPLE_1_INPUT,
   REFORMAT_EXAMPLE_1_OUTPUT,
   TABLE_REFORMAT_PROMPT,
@@ -12,14 +11,6 @@ import {
 
 import { GptWrapper } from "./gpt_wrapper";
 import { glob } from "glob";
-import { APPLIANCE_TYPES } from "../../backend/schema/metadata";
-import {
-  HEAT_PUMP_DRYER_METADATA,
-  HEAT_PUMP_METADATA,
-  HEAT_PUMP_WATER_HEATER_METADATA,
-  SpecsMetadata,
-} from "./schemas";
-import { ModelGeneratedAppliance } from "../../backend/schema/appliance";
 import { retrieveMetadata } from "./metadata";
 
 const SPECS_FILE_BASE = "../data/";
@@ -103,7 +94,7 @@ async function main() {
           try {
             let response = JSON.parse(msg);
             await fs.writeFile(
-              path.join(outputFolder, "reformatted.json"),
+              path.join(outputFolder, "records.json"),
               JSON.stringify(response, null, 2),
               {
                 encoding: "utf-8",

--- a/pipeline/src/reformat_tables.ts
+++ b/pipeline/src/reformat_tables.ts
@@ -64,7 +64,7 @@ async function main() {
       const applianceFolder = path.dirname(inputFolder);
       const outputFolder = path.join(applianceFolder, OUTPUT_SUBDIR);
       await fs.mkdir(outputFolder, { recursive: true });
-      const folderPromises: Promise<void>[] = [];
+      const jsons: any[] = [];
       for (const file of await fs.readdir(inputFolder)) {
         const tableFilePath = path.join(inputFolder, file);
         if (!file.endsWith(".json")) continue;
@@ -78,44 +78,32 @@ async function main() {
           console.log(`Skipping ${tableFilePath} because it is empty`);
           continue;
         }
+        jsons.push(table);
+      }
 
-        if (opts.wait) {
-          await new Promise((f) => setTimeout(f, +opts.wait));
-        }
+      if (opts.wait) {
+        await new Promise((f) => setTimeout(f, +opts.wait));
+      }
 
-        const metadata = await retrieveMetadata(applianceFolder);
-        if (!("applianceType" in metadata)) {
-          throw new Error("applianceType not set in metadata");
-        }
-        const applianceType = metadata.applianceType;
+      const metadata = await retrieveMetadata(applianceFolder);
+      if (!("applianceType" in metadata)) {
+        throw new Error("applianceType not set in metadata");
+      }
+      const applianceType = metadata.applianceType;
 
-        let modelMetadata: SpecsMetadata<ModelGeneratedAppliance>;
-        if (applianceType === APPLIANCE_TYPES.heat_pump) {
-          modelMetadata = HEAT_PUMP_METADATA;
-        } else if (applianceType === APPLIANCE_TYPES.heat_pump_water_heater) {
-          modelMetadata = HEAT_PUMP_WATER_HEATER_METADATA;
-        } else if (applianceType === APPLIANCE_TYPES.heat_pump_dryer) {
-          modelMetadata = HEAT_PUMP_DRYER_METADATA;
-        } else {
-          throw new Error(
-            "No model metadata configured for this appliance type"
-          );
-        }
-
-        console.log(`Querying ${MODEL_FAMILY} with ${tableFilePath}`);
-        const gpt_wrapper = new GptWrapper(MODEL_FAMILY);
-        const queryFunc = gpt_wrapper.queryGpt.bind(gpt_wrapper);
-        const promise = queryFunc(
-          JSON.stringify(table),
-          TABLE_REFORMAT_PROMPT,
-          [[REFORMAT_EXAMPLE_1_INPUT, REFORMAT_EXAMPLE_1_OUTPUT]]
-        ).then(async (msg: string) => {
-          if (msg == "") return;
-          console.log(`Got response from ${tableFilePath}`);
+      console.log(`Querying ${MODEL_FAMILY} with ${applianceFolder}`);
+      const gpt_wrapper = new GptWrapper(MODEL_FAMILY);
+      const queryFunc = gpt_wrapper.queryGpt.bind(gpt_wrapper);
+      const promise = queryFunc(JSON.stringify(jsons), TABLE_REFORMAT_PROMPT, [
+        [REFORMAT_EXAMPLE_1_INPUT, REFORMAT_EXAMPLE_1_OUTPUT],
+      ])
+        .then(async (msg: string) => {
+          if (msg === "") return;
+          console.log(`Got response for ${applianceFolder}`);
           try {
             let response = JSON.parse(msg);
             await fs.writeFile(
-              path.join(outputFolder, file),
+              path.join(outputFolder, "reformatted.json"),
               JSON.stringify(response, null, 2),
               {
                 encoding: "utf-8",
@@ -124,12 +112,13 @@ async function main() {
             );
           } catch (error) {
             console.error(`Error parsing json: ${error}, ${msg}`);
-            droppedFiles.push(tableFilePath);
+            droppedFiles.push(applianceFolder);
           }
+        })
+        .catch((error) => {
+          console.log(`LLM error on ${applianceFolder}: ${error}`);
         });
-        allPromises.push(promise);
-        folderPromises.push(promise);
-      }
+      allPromises.push(promise);
     }
   }
   await Promise.allSettled(allPromises).then(async () => {

--- a/pipeline/src/rename_columns.ts
+++ b/pipeline/src/rename_columns.ts
@@ -22,7 +22,7 @@ import { ModelGeneratedAppliance } from "../../backend/schema/appliance";
 import { retrieveMetadata } from "./metadata";
 
 const SPECS_FILE_BASE = "../data/";
-const INPUT_SUBDIR = "merged/";
+const INPUT_SUBDIR = "reformatted/";
 const OUTPUT_SUBDIR = "renamed/";
 const RUNS = "runs/";
 const MODEL_FAMILY = "gpt"; // eventually support more options
@@ -56,7 +56,7 @@ async function main() {
       const folderPromises: Promise<void>[] = [];
       for (const file of await fs.readdir(inputFolder)) {
         const filteredFilePath = path.join(inputFolder, file);
-        if (!file.endsWith("filtered.json")) continue;
+        if (!file.endsWith("reformatted.json")) continue;
         const applianceRecords = JSON.parse(
           await fs.readFile(filteredFilePath, {
             encoding: "utf8",

--- a/pipeline/src/rename_columns.ts
+++ b/pipeline/src/rename_columns.ts
@@ -56,7 +56,7 @@ async function main() {
       const folderPromises: Promise<void>[] = [];
       for (const file of await fs.readdir(inputFolder)) {
         const filteredFilePath = path.join(inputFolder, file);
-        if (!file.endsWith("reformatted.json")) continue;
+        if (!file.endsWith("records.json")) continue;
         const applianceRecords = JSON.parse(
           await fs.readFile(filteredFilePath, {
             encoding: "utf8",
@@ -104,7 +104,7 @@ async function main() {
           try {
             let response = JSON.parse(msg);
             await fs.writeFile(
-              path.join(outputFolder, file),
+              path.join(outputFolder, "records.json"),
               JSON.stringify(
                 {
                   ...response,

--- a/pipeline/src/schemas.ts
+++ b/pipeline/src/schemas.ts
@@ -32,7 +32,8 @@ export const HEAT_PUMP_METADATA: SpecsMetadata<HeatPumpModelGenerated> = {
       "The required breaker size for the equipment. May also be called Maximum Overcurrent Protection (MOP).",
   },
   voltage: {
-    description: "The required voltage for the equipment.",
+    description:
+      "The required voltage for the equipment. Common values are 120 or 240. Sometimes given along with phase and frequency such as 240-1-60, in which case it will be the first number.",
   },
   soundLevelMin: {
     description: "The minimum sound level in decibels.",
@@ -68,7 +69,8 @@ export const HEAT_PUMP_WATER_HEATER_METADATA: SpecsMetadata<HeatPumpWaterHeaterM
         "The required breaker size for the equipment. May also be called Maximum Overcurrent Protection (MOP).",
     },
     voltage: {
-      description: "The required voltage for the equipment.",
+      description:
+        "The required voltage for the equipment. Common values are 120 or 240. Sometimes given along with phase and frequency such as 240-1-60, in which case it will be the first number.",
     },
     soundLevelMin: {
       description: "The minimum sound level in decibels.",
@@ -111,7 +113,8 @@ export const HEAT_PUMP_DRYER_METADATA: SpecsMetadata<HeatPumpDryerModelGenerated
         "The required breaker size for the equipment. May also be called Maximum Overcurrent Protection (MOP).",
     },
     voltage: {
-      description: "The required voltage for the equipment.",
+      description:
+        "The required voltage for the equipment. Common values are 120 or 240. Sometimes given along with phase and frequency such as 240-1-60, in which case it will be the first number.",
     },
     soundLevelMin: {
       description: "The minimum sound level in decibels.",

--- a/pipeline/src/validate_data.ts
+++ b/pipeline/src/validate_data.ts
@@ -20,7 +20,7 @@ import { APPLIANCE_TYPES } from "../../backend/schema/metadata";
 import { HEAT_PUMP_WATER_HEATER_SCHEMA } from "../../backend/schema/heat_pump_water_heater";
 
 const SPECS_FILE_BASE = "../data/";
-const INPUT_SUBDIR = "renamed/";
+const INPUT_SUBDIR = "corrected/";
 const OUTPUT_SUBDIR = "validated/";
 const RUNS = "runs/";
 
@@ -89,7 +89,7 @@ async function main() {
       const invalid: Table[] = [];
       for (const file of await fs.readdir(inputFolder)) {
         const filteredPath = path.join(inputFolder, file);
-        if (!(file === "filtered.json")) continue;
+        if (!(file === "output.json")) continue;
         const filtered = JSON.parse(
           await fs.readFile(filteredPath, {
             encoding: "utf8",

--- a/pipeline/src/validate_data.ts
+++ b/pipeline/src/validate_data.ts
@@ -89,7 +89,7 @@ async function main() {
       const invalid: Table[] = [];
       for (const file of await fs.readdir(inputFolder)) {
         const filteredPath = path.join(inputFolder, file);
-        if (!(file === "output.json")) continue;
+        if (!(file === "records.json")) continue;
         const filtered = JSON.parse(
           await fs.readFile(filteredPath, {
             encoding: "utf8",


### PR DESCRIPTION
This is a bit of a mega-CL, apologies.

1. Add a stage in between renaming columns and validating the records called correct_data which uses the text of the PDF to fill in things that we're missing. We may move around the order later, but this is a reasonable starting point. It does help with some things like electric breaker size, though it could benefit from some tuning.
2. Pass in all JSON tables together. This both saves us money and lets the LLM use context from previous tables to have a better shot at correctly combining them.
3. #2 de facto makes the merge_tables step unnecessary. I'll update the documentation later since I also need to add documentation for the new stage, but there's an in-progress README move happening right now and I don't want to interrupt that. 
4. That tends to make the input longer and sometimes it doesn't fit. In these cases, we upgrade to GPT4 which has a larger context window.
5. Also standardize on the intermediate stages producing files called `records.json` – we still use the directory names to distinguish the stages but there's not really much use in the files having different names.

@Kevin2162 fyi since this changes some of the filenames, and you'll probably want to mass-rename them (anything the reformatted or renamed directories). It also introduces a new stage and removes an old one (see #1 and #3 above), which isn't documented since I want to wait for your readme PR to land.