### PR TITLE
Add basic evals infrastructure.

### DIFF
--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -17,8 +17,10 @@
         "openai": "^4.20.0"
       },
       "devDependencies": {
+        "@json2csv/node": "^7.0.6",
         "@types/lodash": "^4.14.202",
         "csv": "^6.3.8",
+        "fuse.js": "^7.0.0",
         "tap": "^18.6.1",
         "typescript": "^5.3.2"
       }
@@ -157,6 +159,31 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@json2csv/formatters": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@json2csv/formatters/-/formatters-7.0.6.tgz",
+      "integrity": "sha512-hjIk1H1TR4ydU5ntIENEPgoMGW+Q7mJ+537sDFDbsk+Y3EPl2i4NfFVjw0NJRgT+ihm8X30M67mA8AS6jPidSA==",
+      "dev": true
+    },
+    "node_modules/@json2csv/node": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@json2csv/node/-/node-7.0.6.tgz",
+      "integrity": "sha512-J3AX8cDBeQyriJj0oFxJot52hScUN4hhUBRnUGIPt+yI1YpwUuftriJi1RJS60Uz6Stce1sewHeG56dBc9/XGg==",
+      "dev": true,
+      "dependencies": {
+        "@json2csv/plainjs": "^7.0.6"
+      }
+    },
+    "node_modules/@json2csv/plainjs": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@json2csv/plainjs/-/plainjs-7.0.6.tgz",
+      "integrity": "sha512-4Md7RPDCSYpmW1HWIpWBOqCd4vWfIqm53S3e/uzQ62iGi7L3r34fK/8nhOMEe+/eVfCx8+gdSCt1d74SlacQHw==",
+      "dev": true,
+      "dependencies": {
+        "@json2csv/formatters": "^7.0.6",
+        "@streamparser/json": "^0.0.20"
       }
     },
     "node_modules/@npmcli/agent": {
@@ -339,6 +366,12 @@
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
+    },
+    "node_modules/@streamparser/json": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@streamparser/json/-/json-0.0.20.tgz",
+      "integrity": "sha512-VqAAkydywPpkw63WQhPVKCD3SdwXuihCUVZbbiY3SfSTGQyHmwRoq27y4dmJdZuJwd5JIlQoMPyGvMbUPY0RKQ==",
+      "dev": true
     },
     "node_modules/@tapjs/after": {
       "version": "1.1.17",
@@ -1910,6 +1943,15 @@
       "resolved": "https://registry.npmjs.org/function-loop/-/function-loop-4.0.0.tgz",
       "integrity": "sha512-f34iQBedYF3XcI93uewZZOnyscDragxgTK/eTvVB74k3fCD0ZorOi5BV9GS4M8rz/JoNi0Kl3qX5Y9MH3S/CLQ==",
       "dev": true
+    },
+    "node_modules/fuse.js": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.0.0.tgz",
+      "integrity": "sha512-14F4hBIxqKvD4Zz/XjDc3y94mNZN6pRv3U13Udo0lNLCWRBUsrMv2xwcF/y/Z5sV6+FQW+/ow68cHpm4sunt8Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -7,8 +7,10 @@
   "license": "MIT",
   "private": false,
   "devDependencies": {
+    "@json2csv/node": "^7.0.6",
     "@types/lodash": "^4.14.202",
     "csv": "^6.3.8",
+    "fuse.js": "^7.0.0",
     "tap": "^18.6.1",
     "typescript": "^5.3.2"
   },

--- a/pipeline/src/differ.ts
+++ b/pipeline/src/differ.ts
@@ -1,0 +1,317 @@
+import { AsyncParser } from "@json2csv/node";
+import fs = require("node:fs/promises");
+
+import {
+  SYSTEM,
+  EXAMPLE_1_USER,
+  EXAMPLE_1_RESPONSE,
+} from "./prompts/prompt_evals";
+import { Appliance } from "../../backend/schema/appliance";
+// Not sure why tsc won't allow an import as above, but it doesn't.
+const Fuse = require("fuse.js");
+
+// 0 is an exact match; 1 is a terrible match.
+const FUZZY_MATCH_THRESHOLD = 0.5;
+const KEY_NAME = "Column";
+const ROW_TOTAL = "Row Total";
+
+enum Grade {
+  Unspecified = "Unspecified",
+
+  MissingBoth = "MissingBoth",
+  MissingPipeline = "MissingPipeline",
+  MissingGolden = "MissingGolden",
+  CaseInsensitiveMatch = "CaseInsensitiveMatch",
+
+  FuzzyMatch = "FuzzyMatch",
+  FuzzyNoMatch = "FuzzyNoMatch",
+
+  ModelGradedMatch = "ModelGradedMatch",
+  ModelGradedAlmostMatch = "ModelGradedAlmostMatch",
+  ModelGradedWeakMatch = "ModelGradedWeakMatch",
+  ModelGradedNoMatch = "ModelGradedNoMatch",
+}
+
+// To reduce output constraints on the model, we ask the LLM grader to simply
+// give back a letter rather than a more complicated enum. Then we use this
+// to translate.
+const MODEL_GRADES = new Map<string, Grade>([
+  ["A", Grade.ModelGradedMatch],
+  ["B", Grade.ModelGradedAlmostMatch],
+  ["C", Grade.ModelGradedWeakMatch],
+  ["D", Grade.ModelGradedNoMatch],
+]);
+
+// These fields will be compared by a fuzzy match algorithm to basically test
+// that we got that answer or extremely close.
+const FUZZY_MATCH_FIELDS: (keyof Appliance)[] = [
+  "weight",
+  "dimensions",
+  "electricBreakerSize",
+  "modelVariant",
+  "soundLevelMax",
+  "soundLevelMin",
+  "voltage",
+];
+
+// I'm not sure we'll need this, but since the code was written anyway,
+// I'm inclined to keep it until we're sure we don't want more sophisticated
+// grading.
+const MODEL_GRADED_FIELDS: (keyof Appliance)[] = [];
+
+export interface Diff {
+  diffs: Record<string, DiffVal>;
+  extra_keys?: string;
+  filename?: string;
+  modelNumber?: string;
+}
+
+interface DiffVal {
+  grade?: string;
+  golden: string;
+  pipeline: string;
+  explanation?: string;
+}
+
+export type Report = Array<Record<string, unknown>>;
+
+type ModelQueryFunction = (
+  input_text: string,
+  system: string,
+  examples: Array<[string, string]>
+) => Promise<string>;
+
+export class Differ {
+  modelQueryFunction: ModelQueryFunction;
+
+  constructor(modelQueryFunction: ModelQueryFunction) {
+    this.modelQueryFunction = modelQueryFunction;
+  }
+
+  async modelGradeFields(
+    golden: Partial<Appliance>,
+    pipeline: Partial<Appliance>
+  ): Promise<Diff> {
+    const lastMessage: string = `Expert:
+    ${JSON.stringify(golden)}
+    
+    Student:
+    ${JSON.stringify(pipeline)}`;
+
+    const resp = await this.modelQueryFunction(lastMessage, SYSTEM, [
+      [EXAMPLE_1_USER, EXAMPLE_1_RESPONSE],
+    ]);
+    const diff: Diff = { diffs: {} };
+    try {
+      const parsed = JSON.parse(resp);
+      for (const key in parsed) {
+        diff.diffs[key] = {
+          golden: String(golden[key as keyof Appliance]),
+          pipeline: String(pipeline[key as keyof Appliance]),
+          grade:
+            MODEL_GRADES.get(parsed[key].grade.toUpperCase()) ??
+            Grade.Unspecified,
+          explanation: parsed[key].explanation,
+        };
+      }
+    } catch (err) {
+      console.log(`Error while parsing ${resp}: ${err}`);
+    }
+    return diff;
+  }
+
+  getFuzzyMatchData(
+    golden: string,
+    pipeline: string
+  ): { grade?: string; explanation?: string } {
+    const fuse = new Fuse([golden], { includeScore: true });
+    const res = fuse.search(pipeline, { limit: 1 });
+    const result: { grade?: string; explanation?: string } = {};
+    if (
+      res.length > 0 &&
+      Object.hasOwn(res[0], "score") &&
+      res[0].score! < FUZZY_MATCH_THRESHOLD
+    ) {
+      result.grade = Grade[Grade.FuzzyMatch];
+      result.explanation = `Fuzzy Match score of ${res[0].score} (threshold is ${FUZZY_MATCH_THRESHOLD})`;
+    } else {
+      result.grade = Grade[Grade.FuzzyNoMatch];
+    }
+    return result;
+  }
+
+  getStringRep(value: any): string {
+    if (value === undefined || value === null) {
+      return "Not provided";
+    }
+    if (typeof value === "object") {
+      // Sort object keys ensures consistent representation.
+      return JSON.stringify(value, Object.keys(value).sort());
+    }
+    return JSON.stringify(value);
+  }
+
+  async compareAppliances(
+    golden: Appliance,
+    pipeline: Appliance
+  ): Promise<Diff> {
+    const modelGolden: Record<string, string> = {};
+    const modelPipeline: Record<string, string> = {};
+
+    const diff: Diff = { diffs: {} };
+    for (const k of FUZZY_MATCH_FIELDS.concat(MODEL_GRADED_FIELDS)) {
+      let base: DiffVal = {
+        golden: this.getStringRep(golden[k]),
+        pipeline: this.getStringRep(pipeline[k]),
+      };
+      // We should handle nulls elsewhere in the pipeline, but for now
+      // pretend treat them as undefined.
+      if (Object.hasOwn(pipeline, k) && pipeline[k] === null) {
+        delete pipeline[k];
+      }
+      if (!(Object.hasOwn(golden, k) || Object.hasOwn(pipeline, k))) {
+        base.grade = Grade.MissingBoth;
+      } else if (Object.hasOwn(golden, k) && !Object.hasOwn(pipeline, k)) {
+        base.grade = Grade.MissingPipeline;
+      } else if (Object.hasOwn(pipeline, k) && !Object.hasOwn(golden, k)) {
+        base.grade = Grade.MissingGolden;
+      } else if (
+        String(golden[k]).toLowerCase() == String(pipeline[k]).toLowerCase()
+      ) {
+        base.grade = Grade.CaseInsensitiveMatch;
+      } else {
+        if (FUZZY_MATCH_FIELDS.includes(k)) {
+          base = {
+            ...base,
+            ...this.getFuzzyMatchData(String(golden[k]), String(pipeline[k])),
+          };
+        } else {
+          modelGolden[k] = String(golden[k]);
+          modelPipeline[k] = String(pipeline[k]);
+        }
+      }
+      diff.diffs[k] = base;
+    }
+
+    if (Object.keys(modelGolden).length > 0) {
+      const modelGraded = await this.modelGradeFields(
+        modelGolden,
+        modelPipeline
+      );
+      for (const key in modelGraded.diffs) {
+        if (!(key in diff.diffs)) {
+          console.log(`Model returned unknown key: ${key}`);
+        } else {
+          diff.diffs[key] = modelGraded.diffs[key];
+        }
+      }
+    }
+
+    return diff;
+  }
+
+  sortByModelNumber(appliances: Appliance[]): Appliance[] {
+    return appliances.sort((a, b) => {
+      if (a.modelNumber < b.modelNumber) {
+        return -1;
+      } else if (a.modelNumber === b.modelNumber) {
+        return 0;
+      } else {
+        return 1;
+      }
+    });
+  }
+
+  getComparableAppliances(
+    golden: Appliance[],
+    pipeline: Appliance[]
+  ): [Appliance[], Appliance[]] {
+    if (golden.length !== pipeline.length) {
+      throw new Error(
+        `Different numbers of incentives: golden ${golden.length}, pipeline ${pipeline.length}`
+      );
+    }
+    const sortedGolden = this.sortByModelNumber(golden);
+    const sortedPipeline = this.sortByModelNumber(pipeline);
+    sortedGolden.forEach((g, i) => {
+      // Also check for duplicates.
+      if (i > 0 && g.modelNumber === sortedGolden[i - 1].modelNumber) {
+        throw new Error(
+          `Duplicate model number found in golden array: ${g.modelNumber}`
+        );
+      }
+      if (g.modelNumber !== sortedPipeline[i].modelNumber) {
+        throw new Error(
+          `Golden and pipeline datasets don't contain the same model numbers: found golden ${g.modelNumber} and pipeline ${pipeline[i].modelNumber}`
+        );
+      }
+    });
+    return [golden, pipeline];
+  }
+
+  async compareData(
+    key: string,
+    golden_data: Appliance[],
+    pipeline_data: Appliance[]
+  ): Promise<Diff[]> {
+    const [golden, pipeline] = this.getComparableAppliances(
+      golden_data,
+      pipeline_data
+    );
+
+    const diffs: Diff[] = [];
+    for (let i = 0; i < golden.length; i++) {
+      const diff = await this.compareAppliances(golden[i], pipeline[i]);
+      diff.filename = key;
+      diff.modelNumber = golden[i].modelNumber;
+      diffs.push(diff);
+    }
+    return diffs;
+  }
+
+  createReport(diffs: Diff[]): Report {
+    const keyFrequencies: Map<string, Map<string, number>> = new Map();
+    for (const diff of diffs) {
+      for (const key in diff.diffs) {
+        if (keyFrequencies.get(key) === undefined) {
+          keyFrequencies.set(key, new Map<string, number>());
+        }
+        const freq = keyFrequencies.get(key)!;
+        const grade = diff.diffs[key].grade!;
+        freq.set(grade, 1 + (freq.get(grade) ?? 0));
+        freq.set(ROW_TOTAL, 1 + (freq.get(ROW_TOTAL) ?? 0));
+      }
+    }
+    const report: Report = [];
+    const totals: Map<string, number> = new Map();
+    keyFrequencies.forEach((val, key) => {
+      const row: Record<string, unknown> = {};
+      val.forEach((count, grade) => {
+        row[grade] = count;
+        totals.set(grade, count + (totals.get(grade) ?? 0));
+      });
+      row[KEY_NAME] = key;
+      report.push(row);
+    });
+    const row: Record<string, unknown> = {};
+    row[KEY_NAME] = "Column Totals";
+    totals.forEach((val, grade) => {
+      row[grade] = val;
+    });
+    report.push(row);
+    return report;
+  }
+
+  async writeReport(report: Report, filename: string) {
+    const fields: string[] = [KEY_NAME];
+    const keys = Object.keys(Grade) as (keyof typeof Grade)[];
+    for (const key of keys) {
+      fields.push(Grade[key]);
+    }
+    fields.push(ROW_TOTAL);
+    const parser = new AsyncParser({ fields: fields });
+
+    const csv = await parser.parse(report).promise();
+    fs.writeFile(filename, csv);
+  }
+}

--- a/pipeline/src/prompts/prompt_evals.ts
+++ b/pipeline/src/prompts/prompt_evals.ts
@@ -1,0 +1,57 @@
+export const SYSTEM: string = `You are a helpful assistant that creates diff reports of JSON objects.
+
+You will be given an expert response and a student response in the form of two JSON objects. You will grade the match and return your output in the form of another JSON object with a key for each key in the original objects. The value will be a JSON object containing a grade and your explanation for it.
+
+For each key, first write out in a step by step manner your reasoning to be sure that your conclusion is correct. Avoid simply stating the correct answer at the outset. That will be a key with name "explanation".
+Then add a key named "grade" with a single choice from the following (without quotes or punctuation).
+
+For each key:
+If they are very similar, the grade is "A". They should contain roughly the same words in each value, possibly shuffled around or using synonyms.
+If they are semantically similar, containing mostly the details, the grade is "B". They should contain largely the same concepts but can vary more than for grade A.
+If they have some overlap in details, but also differ significantly, the grade is "C".
+If they seem to have almost no overlap, the grade is "D".
+
+An example value might be be {"explanation": "The student answer doesn't mention light bulbs, whereas the expert answer does, but they both mention a per-consumer limit", "grade": "C"}.
+
+Be sure to return valid JSON. You can mention either the student or expert answers, but don't quote them directly to avoid producing malformed JSON.
+`;
+
+export const EXAMPLE_1_USER: string = `
+Expert:
+{
+    "Technology*": "Heat Pump Water Heater (HPWH)",
+    "Program Description (guideline)": "Rebate up to $200 on an Energy Star certified heat pump water heater",
+    "Program Status": "Active",
+    "Rebate Type": "Rebate (post purchase)",
+    "Rebate Value*": "$200",
+    "Amount Type*": "dollars",
+    "Equipment Standards Restrictions": "• Uniform energy factor of 2.20 for 120V/15A.\n• Must be ENERGY STAR certified.",
+    "Contractor Restrictions": "Work must be performed by a Colorado Contractor. Do-it-yourself work does not qualify.",
+    "Other Restrictions": "Homes must be heated by electric rather than gas to qualify."
+}
+
+Student:
+{
+    "Technology*": "Heat Pump Water Heater",
+    "Program Description (guideline)": "Up to $200 on an Energy Star heat pump water heater",
+    "Program Status": "Paused",
+    "Rebate Type": "Point of sale rebate",
+    "Rebate Value*": "200",
+    "Amount Type*": "dollar amount",
+    "Equipment Standards Restrictions": "Must be ENERGY STAR-certified. UEF of 2.20 for 120V/15A.",
+    "Contractor Restrictions": "Limit 1 per customer per account type. Global amount of $5,000 across all rebates. DIY work is not permitted.",
+    "Other Restrictions": "You will need to file a rebate with 90 days of appliance purchase."
+}`;
+
+export const EXAMPLE_1_RESPONSE = `{
+    "Technology": {"explanation": "The Technology field contains the same concepts with almost the same words.", "grade": "A"},
+    "Program Description (guideline)": {"explanation": "The Program Description (guideline) field have the same dollar value, both mention Energy Star, and are for heat pump water heaters", "grade": "A"},
+    "Program Status": {"explanation": "Program Status has different concepts for student and expert answer", "grade": "D"},
+    "Rebate Type": {"explanation": "Post purchase and point of sale are different kinds of rebates", "grade": "D"},
+    "Rebate Value*": {"explanation": "Student answer is missing a dollar sign, but the value is the same", "grade": "A"},
+    "Amount Type*": {"explanation": "The Amount Type has the same concept with slightly different wording", "grade": "A"},
+    "Equipment Standards Restrictions": {"explanation": "Both answers mention Energy Star certification and have the same technical details", "grade": "B"},
+    "Contractor Restrictions": {"explanation": "The expert answer mentions contractor restrictions. The student answer mentions a global amount and per customer limit. Both answers contain some details on DIY work.", "grade": "C"},
+    "Other Restrictions": {"explanation": "The given answers have no significant overlap.", "grade": "D"}
+}
+`;

--- a/pipeline/src/run_evals.ts
+++ b/pipeline/src/run_evals.ts
@@ -1,0 +1,111 @@
+import { program, Option } from "commander";
+
+import fs = require("node:fs/promises");
+import path = require("node:path");
+
+import { GptWrapper } from "./gpt_wrapper";
+import { Differ, Diff, Report } from "./differ";
+import { glob } from "glob";
+import { Appliance } from "../../backend/schema/appliance";
+
+const SPECS_FILE_BASE = "../data";
+// TODO: we might be able to read for corrected/ instead.
+// Though maybe we want the metadata.
+const INPUT_SUBDIR = "validated/";
+const RUNS = "runs/";
+
+program
+  .requiredOption(
+    "-f, --folders <folders...>",
+    "Name of folder(s) under incentives_data/ where text data is located."
+  )
+  .addOption(
+    new Option(
+      "-m, --model_family <model_family>",
+      "Name of model family to use for model-grading"
+    )
+      .choices(["gpt4", "gpt"])
+      .default("gpt")
+  );
+
+program.parse();
+
+async function main() {
+  const opts = program.opts();
+
+  const promises: Promise<void>[] = [];
+  const diffs: Diff[] = [];
+  const gpt_wrapper = new GptWrapper(opts.model_family);
+  const queryFunc = gpt_wrapper.queryGpt.bind(gpt_wrapper);
+  const differ: Differ = new Differ(queryFunc);
+
+  for (const topFolder of opts.folders) {
+    const folders = await glob(
+      path.join(SPECS_FILE_BASE, topFolder, "**", INPUT_SUBDIR),
+      { ignore: path.join(SPECS_FILE_BASE, RUNS) }
+    );
+    for (const inputFolder of folders) {
+      const applianceFolder = path.dirname(inputFolder);
+
+      // check readiness – do we have both a golden and validated?
+      const goldenFile = path.join(applianceFolder, "golden.json");
+      let goldenData: Appliance[];
+      try {
+        goldenData = JSON.parse(
+          await fs.readFile(goldenFile, { encoding: "utf8" })
+        );
+      } catch (err) {
+        console.log(`No golden found for: ${applianceFolder}`);
+        continue;
+      }
+
+      // read both valid and invalid
+      const allRecords = [];
+      for (const file of await fs.readdir(inputFolder)) {
+        const records: Appliance[] = JSON.parse(
+          await fs.readFile(path.join(inputFolder, file), { encoding: "utf-8" })
+        );
+        if (records.length === 0) continue;
+        if (file === "invalid.json") {
+          const noErrors = records.map((record: Appliance) => {
+            if ("errors" in record) {
+              delete record["errors"];
+            }
+            return record;
+          });
+          allRecords.push(...noErrors);
+        }
+      }
+
+      const promise = differ
+        .compareData(applianceFolder, goldenData, allRecords)
+        .then((diff) => {
+          diffs.push(...diff);
+        })
+        .catch((err) => {
+          console.log(`diffing error: ${err}`);
+        });
+      promises.push(promise);
+    }
+
+    await Promise.allSettled(promises).then(async () => {
+      const runId = Date.now().toString();
+      const outputDir = path.join(SPECS_FILE_BASE, RUNS, runId);
+      await fs.mkdir(outputDir);
+      console.log(`Final diffs and report written to ${outputDir}`);
+      await fs.writeFile(
+        path.join(outputDir, "diff.json"),
+        JSON.stringify(diffs, null, 2) + "\n",
+        {
+          encoding: "utf-8",
+          flag: "w",
+        }
+      );
+
+      const report: Report = differ.createReport(diffs);
+      differ.writeReport(report, path.join(outputDir, "report.csv"));
+    });
+  }
+}
+
+main();

--- a/pipeline/tsconfig.json
+++ b/pipeline/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES6",
+    "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "declaration": false,


### PR DESCRIPTION
Usage will be documented in the readme once it's moved, but it's run as a final stage after validate_data.ts (at least so far).

Run: `npx ts-node src/run_evals.ts  --folders heat-pumps/rheem/` (as an example)

In order for it to do anything, it expects a file called `golden.json` to live in each appliance folder (e.g. next to the `raw.pdf`). That should contain the "answer key" or correct appliance specs as validated by a human. Right now we can only compare files with the same appliances in them (i.e. same exact model numbers), though in theory we could remove that limitation.

This is adapted heavily from https://github.com/rewiringamerica/incentive-data-llm, so there are some things that aren't used yet, but I didn't want to throw away just yet (the ability to have LLMs grade more nuanced answers).