### PR TITLE
Add more data that we should start versioning.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,7 @@ data/**/reformatted/
 data/**/renamed/
 data/**/merged/
 data/**/validated/
+data/**/corrected/
 data/runs/*
 data/**/filtered.json
 data/**/merged.json

--- a/data/heat-pump-water-heaters/rheem/performance-platinum/raw.txt
+++ b/data/heat-pump-water-heaters/rheem/performance-platinum/raw.txt
@@ -1,0 +1,193 @@
+PERFORMANCE PLATINUMTM ProTerra Hybrid
+Electric with LeakGuardTM is the most efficient
+water heater available
+
+Efficiency                                 Operation Modes                                                                                            30 Amps
+
+ Up to 4.07 UEF reduces ­operating          Energy Saver                                                                              PERFORMANCE PLATINUM
+   cost                                                                                                                                             Hybrid
+                                            Heat Pump
+ E NERGY STAR® rated                                                                                                                         40, 50, 65 and 80-Gallon
+                                            High Demand                                                                                               Capacities
+Performance
+                                            Electric                                                                                            208-240 Volt / 1 PH
+ Delivers hot water faster than most                                                                                                                    Electric
+   standard electric water heaters          V acation/Away: 2-28 days (or placed
+                                              on hold indefinitely)                                                                                                             LEED Points = 3
+ A mbient operating range: 37-145° F
+   is widest in class, offering more days  Plus...
+   of HP operation annually; designed to
+   meet Northern Climate Spec (Tier 4)      Premium grade anode rod with
+                                              ­resistor extends the life of the tank
+Easy Installation
+                                            3/4" NPT water inlet and outlet;
+ Easy access side connections                 3/4" condensate drain connections
+
+ Quick access to electrical junction        Incoloy stainless steel resistor
+   box                                        ­elements
+
+ Easily replaces a standard electric        Dry-fire protection
+   water heater
+                                            Easy access, top mounted washable
+Integration                                   air filter
+
+ L ED Screen with built-in water            2" Non-CFC foam insulation
+   sensor alert with audible alarm
+                                            Enhanced flow brass drain valve
+ Integrated EcoNet® WiFi-­connected1
+   ­technology (2.4 GHz only) and free      Temperature and pressure relief valve
+   mobile app gives users c­ ontrol           installed
+   over water systems, ­allowing for
+   ­customizable ­temperature, ­vacation    Design certified to NSF/ANSI 372
+   settings, ­energy savings and system       (Lead Content)
+   ­monitoring at home or away.
+   Visit Rheem.com/hybridsolutions         Warranty
+
+ Integrated leak detection and              1 0-Year limited tank and parts
+   ­prevention system with factory            warranty
+   ­installed auto water shut-off valve
+   ­limits leaks to no more than 20        See Residential W­ arranty ­Certificate for ­complete
+   ounces of water2                           ­information
+
+ LeakSenseTM Built-in Leak ­Detection      Units meet or exceed ANSI requirements and have
+   System detects any leak large or        been tested according to D.O.E. procedures. Units
+   small, internal or external3            meet or exceed the energy efficiency requirements
+                                           of NAECA, ASHRAE standard 90, ICC Code and all
+ Demand Response Ready -                   state energy efficiency performance criteria.
+   CTA-2045 Port easily connects to
+   utility programs
+
+1WiFi broadband internet connection required. 2Source: Rheem Leak-Sensing Data; testing under a vacuum lock using 50-gallon           See specifications chart on back.
+tank, no e­ xpansion tank, average tank pressure of 40 psi, ­assuming no additional faucets are opened. 3Water leaks from the heater
+only, as tested across scenarios including a minimum of 5.5mL/hr ­volume leak rate, using most common installation scenarios.                                                          12/22 FORM NO. THD-PPEH5-30SO Rev. 5
+                                                                                   Hybrid Specifications
+
+Fuel Type  Desc.  Nominal  Rated            Model     Electric  Uniform     Element  Compressor  First Hr.  Recovery     Tank     Diam.    Ht. to    Ht. to   Unit   Approx.
+                   Gallon  Gallon          Number     Breaker   Energy      Wattage     Btu/H    Rating      in G.P.H.  Height      B    Cold Inlet   Hot     Wt.    Ship Wt.
+ Electric           Cap.    Cap.                                Factor                            G.P.H.    90° F Rise                    & Drain    Outlet  (LBS.)   (LBS.)
+ Electric                              XE40T10HS45U0    Size     (UEF)                                                     A                         & T&P
+ Electric                              XE50T10HS45U0                                                60          26                         Valve
+ Electric                              XE65T10HS45U0     30       3.83                              67          27       63"
+                                       XE80T10HS45U0     30       3.88      30 AMPS - SHUT OFF      75          27       62"
+                                                         30       4.05                              87          27       65"
+           Tall   40               36                    30       4.07      4,500    4200                                75"      20-1/4" 3-5/8" 39-5/8" 157         174
+
+           Tall   50               45                                       4,500    4200                                         22-1/4" 3-5/8" 39-5/8" 178         218
+
+           Tall   65               59                                       4,500    4200                                         24-1/4" 3-7/8" 42-3/8" 225         262
+
+           Tall   80               72                                       4,500    4200                                         24-1/4" 3-7/8" 42-3/8" 244         281
+
+                                          I                                                                 2" Clearance Needed
+                                                            J                                               for T&P Release
+
+                                                                                                                F
+
+                                                                                                                                 G
+
+                                                                                                            B
+
+                                                         H
+                                                                                A
+                                                                                      C
+                                                                                            E
+
+                                                                                                 DD
+
+           DESCRIPTION                                                                      DIMENSIONS (SHOWN IN INCHES)
+
+NOMINAL                     MODEL      A              B                  C            D            E          F             G              H           I                J
+ GALLON                    NUMBER                                                    3-5/8       39-5/8     23-3/8        20-1/2         78-7/8      22-3/8          23-1/4
+CAPACITY            XE40T10HS45U0      62-5/16        20-1/4    47                   3-5/8       39-5/8     25-3/8        22-1/2         78-5/8      24-3/8          25-9/16
+                    XE50T10HS45U0                                                    3-7/8       42-3/8     27-1/2        24-5/8         81-1/8      26-1/2          27-3/8
+    40              XE65T10HS45U0      61-3/4         22-1/4    47                   3-7/8       42-3/8     27-1/2        24-5/8                     26-1/2          27-3/8
+                    XE80T10HS45U0                                                                                                          91
+    50                                 64-3/16        24-1/4    49
+
+    65                                 74-3/16        24-1/4    59
+
+    80
+
+                                                                                                                                                                               2
+Hybrid Water Heater Installation Guidelines to Provide Optimal Efficiency
+
+Heater: Not Ducted                                     Heater: Not Ducted
+
+Room size: Larger than 700 ft3 (e.g. 7' x 10' x 10').  Room size: Smaller than 700 ft3 (e.g. 7' x 10' x 10').
+Requirements: No additional ventilation needed.        Requirements: Full louvered door OR two louvers
+                                                       top and bottom. See below.
+
+                      Heater: Not ducted
+
+                      Room: Small Closet
+                      Requirements: * Air gap under door equal to 18 in2 (0.75" clearance).
+
+                                          * Louver must be located the same height on door as
+                                            the air exhaust on heater.
+
+                                          * Heater air exhaust must be positioned towards louver
+                                            within one foot of door.
+
+                                                                      Air exhaust
+
+           .75"  24"
+
+                                                       12" Max  Door
+
+Heater: Ducted with inlet OR outlet duct               Heater: Ducted with inlet AND outlet duct
+
+Room size: Any size room                               Room size: Any size room
+Requirements: Air gap under door equal to 18 in2       Requirements: No additional ventilation needed.
+(0.75" clearance)
+
+.75"  24"
+
+                                                                                                               3
+Hybrid Accessories List
+
+PART NUMBER                          DESCRIPTION                                                  USE FOR
+                                                                Automatic detection of internal and external leaks
+AP19134               Leak Sensor                               Automatic shut off of water supply to unit
+                                                                Allows for ducting to be connected on the top inlet
+AP20180               Shutoff Valve                             Allows for ducting to be connected to the unit
+                                                                Installations in seismic regions
+SP21105               Inlet Duct Adapter Kit                    Installation on non-concrete floors
+                                                                Termination to the outside or to the attic with 8" diameter
+SP17829               Outlet Duct Adapter Kit                   Termination to the outside or to the attic with 7" diameter
+                                                                Termination to the outside or to the attic with 6" diameter
+SP20882               Earthquake Isolation Kit                  Termination to the outside or to the attic with 5" diameter
+                                                                Exhaust only to the outside ducting configuration (no inlet duct)
+SP20883               Vibration Isolation Kit                   For up to 25' of ducting
+                                                                Installation in tight places where space needs to be minimized
+SP20884               8" Diameter UL Certified Termination Kit
+
+SP20885               7" Diameter UL Certified Termination Kit
+
+SP20886               6" Diameter UL Certified Termination Kit
+
+SP20887               5" Diameter UL Certified Termination Kit
+
+SP20888               8" Rheem Approved Damper Kit
+
+SP20889               25' Flexible 8" Diameter Duct Kit
+
+SP20890               Rigid Elbow Duct Kit
+
+Leak Sensor                                    Shutoff Valve    Inlet Duct Adapter Kit          Outlet Duct Adapter Kit
+
+Earthquake Isolation Kit             Vibration Isolation Kit    8" Diameter UL Certified        7" Diameter UL Certified
+                                                                      Termination Kit                 Termination Kit
+
+6" Diameter UL Certified             5" Diameter UL Certified   8" Rheem Approved Damper Kit    25' Flexible 8" Diameter Duct Kit
+      Termination Kit                      Termination Kit
+
+Rigid Elbow Duct Kit
+
+In keeping with its policy of continuous progress and product improvement, Rheem reserves the right to make changes without notice.
+
+                                     Rheem Water Heating · 1115 Northmeadow Parkway, Suite 100
+
+                                                Roswell, Georgia 30076 · www.rheem.com                                               4
+
+                                                                                                12/22 FORM NO. THD-PPEH5-30SO Rev. 5
+

--- a/data/heat-pump-water-heaters/rheem/proterra-plugin-120v-dedicated/raw.txt
+++ b/data/heat-pump-water-heaters/rheem/proterra-plugin-120v-dedicated/raw.txt
@@ -1,0 +1,210 @@
+                                                                                                    Water  Residential Electric
+                                                                                                           ProTerra Plug-in Heat Pump
+                                                                                                           (Dedicated Circuit) Water Heaters
+
+ProTerra® Plug-In Heat Pump Water Heater
+(120V Dedicated Circuit)
+
+Efficiency                                   Operation Modes                                             ProTerra Plug-in
+                                                                                                             Heat Pump
+· Up to 3.0 UEF reduces ­operating cost      · Heat Pump
+· ENERGY STAR® rated                                                                                (120V Dedicated Circuit)
+· Title 24 Compliant (JA13 Ready)            · Vacation/Away: 2-28 days (or placed
+                                               on hold indefinitely)                                       40 and 50 Capacities
+Performance                                                                                                   120 Volt / 1 PH
+                                             Plus...                                                               Electric
+· Ambient operating range: 37-145° F
+  is widest in class designed to meet        · Premium grade anode rod with                                                          These products meet a stringent
+  Northern Climate Spec (Tier 2)               ­resistor extends the life of the tank                                                set of our internally defined
+                                                                                                                                     sustainability standards.
+Easy Installation                            · 3/4" NPT water inlet and outlet;
+                                               3/4" condensate drain connections
+· Easy access side connections
+· Factory installed plug-in power cord,      · Easy access, top mounted washable
+                                               air filters
+  direct plug-in
+· Easily replaces a standard gas water       · 2" Non-CFC foam insulation
+
+  heater                                     · Enhanced flow brass drain valve
+
+Integration                                  · Temperature and pressure relief valve
+                                               installed
+· LED display allows easy control and
+  system monitoring with alerts and          · Design certified to NSF/ANSI 372
+  audible alarms1                              (Lead Content)
+
+· Integrated EcoNet® Wi-Fi-­connected2       Warranty
+  ­technology and free mobile app
+  gives users ­control over water heater,    · 10-Year limited tank and parts
+  ­allowing for ­customizable ­temperature,    warranty
+  ­vacation settings, energy savings and
+  system monitoring at home or away          See Residential W­ arranty ­Certificate for ­complete
+                                                ­information
+· LeakGuardTM and LeakSenseTM
+  Ready -- Easily add leak detection         Units meet or exceed ANSI requirements and have
+  and ­prevention with leak sensor and       been tested according to D.O.E. procedures. Units
+  ­shutoff valve upgrade kit                 meet or exceed the energy efficiency requirements
+                                             of NAECA, ASHRAE standard 90, ICC Code and all
+· Demand Response Ready - Built-in           state energy efficiency performance criteria.
+  EcoPortTM (CTA-2045 Port) allows easy
+  connection to Utility programs
+
+1Requires additional leak sensing accessory. 2Wi-Fi broadband internet connection required.                                                  LEED Points = 3
+
+                                                                                                    See specifications chart on next page.
+
+                                             IINNTTEEGGRRAATETDE DHOHMOEMCEOCMOFOMRFTO RT
+
+                                                                                                           11/23 FORM NO. RH-PIHP-DC Rev. 4
+ProTerra Plug-in Heat Pump (120V Dedicated Circuit) Specifications
+
+                                          DESCRIPTION                                                      ENERGY                FEATURES                                   TANK DIMENSIONS
+                                                                                                             INFO
+                                                                                                                                                                (SEE SPACE REQUIREMENTS IN DIAGRAMS BELOW)
+                                                                                                           UNIFORM
+NOMINAL     RATED              MODEL       MODEL       ELECTRIC    VOLTAGE                       AVERAGE    ENERGY   COMPRESSOR  SOUND      UEF     RECOVERY    HEIGHT   DIAM.  UNIT                 APPROX.
+ GALLON    GALLON             NUMBER      VARIANT       BREAKER     120V                       ELECTRICAL   FACTOR        BTU/H  LEVEL   FIRST HR.    IN G.P.H      A       B    WT.                 SHIP WT.
+CAPACITY  CAPACITY                                                  120V                                                          (dBA)             60° F RISE                  (LBS)
+                    PROPH40 T0 RH120      700948           SIZE                                  WATTAGE      (UEF)                       RATING                65-5/8  20-1/4                         (LBS.)
+                                                       (MINIMUM)1                                                                          G.P.H.       28                      200
+                    PROPH50 T0 RH120      700949                                                 1100W        3.0                                                 65    22-1/4                         242
+40        37                                               15                                                        12,000      55      51             29                      210
+                                                                                                 1100W        3.0                                                                                      252
+50        46                                               15                                                        12,000      55      51
+
+Uniform Energy Factor and rated gallon capacity based on Department of Energy (DOE) requirements.
+All units have integrated Wi-Fi control board.
+1In cases of fused protection, a time delay fused protection will be required.
+
+  INITIAL TANK            FINAL           HEAT UP TIME (MIN)               Heat Up Time (min)                      Heat Up Time To 120°F vs Initial Tank Water Temp. @ Ambient Air Temperature 75°F
+WATER TEMP (°F)     TANK TEMP (°F)                91.1                                         100
+                                                  83.7
+       40                 120                     77.4                                          75
+       50                 120                     67.1
+       58                 120                      51                                           50
+       70                 120                     37.2
+       87                 120
+       100                120
+
+                                                                                               25
+
+                                                                                               0                     55                             70                  85                           100
+                                                                                                 40
+
+                                                                                                                                 Initial Tank Water Temperature (°F)
+
+                                                                                                                                         2" Clearance Needed
+                                                                                                                                         for T&P Release
+
+                                                                                                                                             F
+
+                                                                   I
+                                                                                                                                          G
+
+                                                                                                                                         B
+
+                                                                   H
+                                                                                           A
+                                                                                                 C
+                                                                                                       E
+
+                 DESCRIPTION                                                                                    D
+
+                                   MODEL                           Insulate ducting to reduce condensation.
+                                  NUMBER
+                             PROPH40                                                                      DIMENSIONS (SHOWN IN INCHES)
+                             PROPH50
+NOMINAL                                                  A           B                                 C       D                   E            F                 G       H               I
+ GALLON                                                65-5/8      20-1/4                          47-13/16  3-5/8               39-5/8      23-3/8             20-1/2    81           21-3/4
+CAPACITY                                                           22-1/4                           47-1/4   3-5/8               39-5/8      25-3/8             22-1/2  80-3/8         21-3/4
+                                                         65
+    40
+
+    50
+
+                                                                                                                                                                                                               2
+Plug-in Heat Pump (Dedicated Circuit) Water Heater
+Installation Guidelines to Provide Optimal Efficiency
+
+All volume is cubic feet.
+
+Not Ducted                                                              Not Ducted
+
+Room size: Larger than 1200 ft3 (e.g. 12' x 10' x 10').                 Room size: 400 ft3 (e.g. 5' x 8' x 10') to 1200 ft3
+Requirements: No additional ventilation needed.                         (e.g. 12' x 10' x 10').
+
+                                                                        Requirements: Full louvered door OR two louvers top and
+                                                                        bottom. 2.9 ft2 minimum louver area.
+
+Ducted with outlet duct                                                 Insufficient air circulation may result in an ­ambient
+                                                                        air temperature drop more than 15° F (8° C) and
+Room size: Smaller than 400 ft3 (5' x 8' x 10') such as a closet.       inefficient operation. Refer to the room size volume
+Requirements: Full louvered door. 3.25 ft2 minimum louver area.         illustrations to determine optimal installation and if
+                                                                        exhaust should be ducted.
+                                                     Insulate ­ducting
+                                                     to reduce          Installation Space Volume is the unoccupied, free
+                                                     ­condensation.     air space required for optimal operation. Additional
+                                                                        objects occupying the space reduce total space
+                                                                        volume.
+
+                                                                        For optimal operation, installation in gray US map zone
+                                                                        is recommended. When installing outside of gray zone,
+                                                                        consult your local plumbing contractor.
+
+MINIMUM CLEARANCES (WITHOUT DUCTING)
+
+REAR  SIDES                TOP                                          Average Ambient Air Temp in January
+                                                                                             Below 37°F
+0"    3"                   9"                                                                Above 37°F
+                                                                                                                                                              3
+                                                                                                                  Water  Residential Electric
+                                                                                                                         ProTerra Plug-in Heat Pump
+                                                                                                                         (Dedicated Circuit) Water Heaters
+
+ProTerra Plug-in Heat Pump Accessories List
+
+PART NUMBER   Leak Sensor DESCRIPTION                                                       USE FOR
+    AP18944D                                            Automatic detection of internal and external leaks
+
+AP20180       Shutoff Valve                             Automatic shut off of water supply to unit
+
+AP21851       Outlet Duct Adapter                       Allows for ducting to be connected to the unit
+
+SP20882       Earthquake Isolation Kit                  Installations in seismic regions
+
+SP20883       Vibration Isolation Kit                   Installation on non-concrete floors
+
+SP20884       8" Diameter UL Certified Termination Kit  Termination to the outside or to the attic with 8" diameter
+
+SP20885       7" Diameter UL Certified Termination Kit  Termination to the outside or to the attic with 7" diameter
+
+SP20886       6" Diameter UL Certified Termination Kit  Termination to the outside or to the attic with 6" diameter
+
+SP20887       5" Diameter UL Certified Termination Kit  Termination to the outside or to the attic with 5" diameter
+
+SP20888       8" Pro Approved Damper Kit                Exhaust only to the outside ducting configuration (no inlet duct)
+
+SP20889       25' Flexible 8" Diameter Duct Kit         For up to 25' of ducting
+
+SP21111       Leak Sensor & Shutoff Valve Kit           Upgrade models to protect home from water damage with leak detection
+                                                        and auto shutoff valve
+
+AP18944D                                  AP20180       AP21851                                                          SP20882
+
+SP20883                                   SP20884       SP20885                                                          SP20886
+
+SP20887                                   SP20888       SP20889                                                                     SP21111
+
+                                                                                                                  UPGRADE KIT (for ProTerra
+                                                                                                                  models without LeakGuard
+                                                                                                                  only) - Add leak detector and
+                                                                                                                  shuttoff valve to protect from
+                                                                                                                  water damage
+
+In keeping with its policy of continuous progress and product improvement, Rheem reserves the right to make changes without notice.
+
+                             Rheem Water Heating · 1115 Northmeadow Parkway, Suite 100                                                               4
+                                           Roswell, Georgia 30076 · www.rheem.com
+                                                                                                                         11/23 FORM NO. RH-PIHP-DC Rev. 4
+                                                                    IINNTTEEGGRRAATETDE DHOHMOEMCEOCMOFOMRFTO RT
+

--- a/data/heat-pump-water-heaters/rheem/proterra-plugin-120v-shared/raw.txt
+++ b/data/heat-pump-water-heaters/rheem/proterra-plugin-120v-shared/raw.txt
@@ -1,0 +1,221 @@
+                                                                                                       Water  Residential Electric
+                                                                                                              ProTerra Plug-in Heat Pump
+                                                                                                              (Shared Circuit) Water Heaters
+
+ProTerra® Plug-in Heat Pump Water Heater
+with ­HydroBoost (120V Shared Circuit)
+
+Efficiency                                   Operation Modes                                              Shared Circuit Design
+
+· Up to 3.5 UEF reduces ­operating cost      · Heat Pump                                                  ProTerra Plug-in
+                                             · V acation/Away: 2-28 days (or placed                       Heat Pump with
+· ENERGY STAR® certified
+                                               on hold indefinitely)                                         ­HydroBoost
+· T itle 24 Compliant (JA13 Ready)                                                                     (120V Shared Circuit)
+                                             Plus...
+Performance                                                                                              40, 50, 65 and 80-Gallon
+                                             · Premium grade anode rod extends                                    Capacities
+· Delivers hot water more efficiently than     the life of the tank
+  most standard electric water heaters                                                                         120 Volt / 1 PH
+                                             · 3/4" NPT water inlet and outlet;                                     Electric
+· Ambient operating range: 37-145°F            3/4" condensate drain connections
+  is widest in class, offering more days                                                                                         These products meet a stringent
+  of HP operation annually; designed to      · Easy access, top mounted washable                                                 set of our internally defined
+  meet Northern Climate Spec                   air filter                                                                        sustainability standards.
+  (NEEA Tier 2)2
+                                             · 2" Non-CFC foam insulation                                                            LEED Points = 3
+· Integrated HydroBoost mixing valve         · Enhanced flow brass drain valve
+  maximizes output performance               · Temperature and pressure relief valve
+
+Easy Installation                              installed
+                                             · Design certified to NSF/ANSI 372
+· Easy access side connections
+                                               (Lead Content)
+· Factory installed plug-in power
+  cord - plugs directly into a standard      Warranty
+  wall outlet
+                                             · 10-Year limited tank and parts
+· Easily replaces a standard gas               warranty
+  water heater
+                                             See Residential W­ arranty ­Certificate for ­complete
+Integration                                     ­information
+
+· Demand Response Ready -                    Units meet or exceed ANSI requirements and have
+  Built-in EcoPort (CTA-2045 Port)           been tested according to D.O.E. procedures. Units
+  allows easy ­connection to Utility         meet or exceed the energy efficiency requirements
+  programs                                   of NAECA, ASHRAE standard 90, ICC Code and all
+                                             state energy efficiency performance criteria.
+· LED Screen with built-in water
+  sensor alert with audible alarm1           1Available with select models. 2Wi-Fi broadband internet
+                                             connection required.
+· Integrated EcoNet® Wi-Fi-­connected2
+  ­technology and free mobile app
+  gives users ­control over water heater,
+  ­allowing for ­customizable ­temperature,
+  ­vacation settings, scheduling, ­energy
+  savings and ­system m­ onitoring at
+  home or away
+
+· LeakGuardTM and LeakSenseTM
+  Ready -- Easily add leak detection
+  and ­prevention with leak sensor and
+  ­shutoff valve upgrade kit
+
+                                                                                                       See specifications chart on next page.
+
+                                             IINNTTEEGGRRAATETDE DHOHMOEMCEOCMOFOMRFTO RT
+
+                                                                                                              12/23 FORM NO. RH-PIHP-SC Rev. 3
+ProTerra Plug-in Heat Pump with HydroBoost (120V Shared Circuit) Specifications
+
+                       DESCRIPTION                                              ENERGY INFO                      FEATURES                             TANK DIMENSIONS
+
+                            MODEL                                                                                                         (SEE SPACE REQUIREMENTS IN DIAGRAMS BELOW)
+                           NUMBER
+NOMINAL     RATED                           MODEL       ELECTRIC      AVERAGE   UNIFORM            COMPRESSOR      FIRST HR.  RECOVERY    HEIGHT  DIAM.    UNIT     APPROX.
+ GALLON    GALLON                           VARIANT      BREAKER    ELECTRICAL  ENERGY                  BTU/H        RATING     IN G.P.H      A      B      WT.     SHIP WT.
+CAPACITY  CAPACITY                                                              FACTOR                                        60° F RISE                   (LBS)
+                                                            SIZE      WATTAGE                                      (GALLONS)                                          (LBS.)
+                                                        (MINIMUM)1                 (UEF)
+
+40        36        PROPH40 T0 RH120-M 701460           15              440W         2.8                   4200    45            12       63"     20-1/4"  157      194
+
+50        46        PROPH50 T0 RH120-M 701453           15              440W         3.0                   4200    55            12       62"     22-1/4"  178      218
+
+65        59        PROPH65 T0 RH120-M 700950           15              395W         3.3                   4200    55            12       65"     24-1/4"  225      262
+
+80        72        PROPH80 T0 RH120-M 700951           15              395W         3.5                   4200    72            12       75"     24-1/4"  244      281
+
+Uniform Energy Factor and rated gallon capacity based on Department of Energy (DOE) requirements.
+All units have integrated Wi-Fi control board.
+1In cases of fused protection, a time delay fused protection will be required.
+
+                                             "2" clearance needed
+                                             for T&P release
+
+                                             F
+
+                                                                        I                                                                 J
+
+                                                     B
+
+                    A                                                                                                                                 H
+                            C
+                                                                                                                                               G
+                                                                                E                                                         K
+                                                                        D
+
+          DESCRIPTION                                                                              DIMENSIONS (SHOWN IN INCHES)
+
+NOMINAL              MODEL          A                B              C           D                    E        F       G            H              I           J        K
+ GALLON             NUMBER                                                    3-5/8                39-5/8  25-3/8  41-7/8        78-7/8          25        23-1/4   4-11/16
+CAPACITY                                                                      3-5/8                39-5/8  27-3/8  41-1/2        78-5/8        27-3/8      25-9/16  4-5/16
+                                                                              3-7/8                42-3/8  29-1/2  44-1-16       81-1/8          29        28-1/16
+40        PROPH40 T0 RH120-M        62-5/16  20-1/4                 47        3-7/8                42-3/8  29-1/2  54-5-16                       29        27-3/8       5
+                                                                                                                                   91                               5-1/16
+50        PROPH50 T0 RH120-M        61-3/4   22-1/4                 47
+
+65        PROPH65 T0 RH120-M        64-3/16  24-1/4                 49
+
+80        PROPH80 T0 RH120-M        74-3/16  24-1/4                 59
+
+                                                                                                                                                                                      2
+Plug-in Heat Pump with HydroBoost Water Heater Installation Guidelines
+to Provide Optimal Efficiency
+
+Heater: Not Ducted                                                        Heater: Not Ducted
+
+Room size: Larger than 700 ft3                                            Room size: Smaller than 700 ft3
+(e.g. 7' x 10' x 10').                                                    (e.g. 7' x 10' x 10').
+
+Requirements:                                                             Requirements:
+No additional                                                             Full louvered door OR
+ventilation needed                                                        two louvers top and
+                                                                          bottom. See to right.
+
+Heater: Ducted With Inlet                                                 Heater: Ducted With Inlet
+or Outlet Duct                                                            and Outlet Duct
+
+Room size:                                                                Room size:
+Any size room                                                             Any size room
+
+Requirements: Air gap                                                     Requirements:
+under door equal to                                                       No additional
+18 in2 (0.75" clearance)                                                  ventilation needed
+
+Notice                                                                    For optimal operation, installation in gray US map zone
+                                                                          is recommended. When choosing the proper water
+If air temperature in installed location drops more than 15°F (8°C)       heater, consult your local plumbing contractor.
+during heating, air circulation is insufficient for efficient operation.
+Utilize ducting to direct cold exhaust air to another location
+
+                                               Air
+                                               Exhaust
+
+.25" 24"                        12" Max" Door
+
+Heater: Not Ducted                                                        Average Ambient Air Temp in January
+                                                                                               Below 37°F
+Room size: Small Closet                                                                        Above 37°F
+
+Requirements:                                                                                                                                             3
+· Air gap under door equals to 18 in2 (0.75" clearance).
+· Louver must be located the same height on door as the air
+
+  exhaust on heater.
+· Heater air exhaust must be positioned towards louver within
+
+  one foot of door.
+
+MINIMUM CLEARANCES (WITHOUT DUCTING)
+
+REAR      SIDES                 TOP
+
+0"        0"                    6"
+                                                                                                     Water  Residential Electric
+                                                                                                            ProTerra Plug-in Heat Pump
+                                                                                                            (Shared Circuit) Water Heaters
+
+Plug-in Heat Pump with HydroBoost Service Parts and Accessories List
+
+PART NUMBER                      DESCRIPTION                                               USE FOR
+AP19134      Leak Sensor                               Automatic detection of internal and external leaks
+AP20180      Shutoff Valve                             Automatic shut off of water supply to unit
+AP21365      Inlet Duct Adapter                        Allows for ducting to be connected on the top inlet
+AP17829      Outlet Duct Adapter                       Allows for ducting to be connected to the unit
+SP20882      Earthquake Isolation Kit                  Installations in seismic regions
+SP20883      Vibration Isolation Kit                   Installation on non-concrete floors
+SP20884      8" Diameter UL Certified Termination Kit  Termination to the outside or to the attic with 8" diameter
+SP20885      7" Diameter UL Certified Termination Kit  Termination to the outside or to the attic with 7" diameter
+SP20886      6" Diameter UL Certified Termination Kit  Termination to the outside or to the attic with 6" diameter
+SP20887      5" Diameter UL Certified Termination Kit  Termination to the outside or to the attic with 5" diameter
+SP20888      8" Rheem Approved Damper Kit              Exhaust only to the outside ducting configuration (no inlet duct)
+SP21105      Inlet 25' Flexible 8" Diameter Duct Kit   For up to 25' of ducting
+SP17829      Outlet 25' Flexible 8" Diameter Duct Kit  For up to 25' of ducting
+SP20890      Rigid Elbow Duct Kit                      Installation in tight places where space needs to be minimized
+                                                       Upgrade models to protect home from water damage with leak detection
+SP21111      Leak Sensor & Shutoff Valve Kit           and auto shutoff valve
+
+AP19134      AP20180                                   AP21365                                              AP17829
+
+SP20882      SP20883                                   SP20884                                              SP20885
+
+SP20886      SP20887                                   SP20888                                       SP21105 / SP17829
+
+             UPGRADE KIT (for ProTerra
+             models without LeakGuard
+             only) - Add leak detector and
+             shuttoff valve to protect from
+             water damage
+
+SP20890                                                SP21111
+
+In keeping with its policy of continuous progress and product improvement, Rheem reserves the right to make changes without notice.
+
+                                           Rheem Water Heating · 1115 Northmeadow Parkway, Suite 100
+                                                          Roswell, Georgia 30076 · www.rheem.com
+
+                                                       IINNTTEEGGRRAATETDE DHOHMOEMCEOCMOFOMRFTO RT                                    4
+
+                                                                                                            12/23 FORM NO. RH-PIHP-SC Rev. 3
+

--- a/data/heat-pumps/rheem/classic-plus-three-stage-rp17/raw.txt
+++ b/data/heat-pumps/rheem/classic-plus-three-stage-rp17/raw.txt
@@ -1,0 +1,1145 @@
+                                                                             Heat Pumps
+                                                                     Air
+
+                                                                             RP17 Series
+
+Rheem Classic Plus® Series
+Three-Stage Heat Pump
+
+                       RP17 Series
+
+                           Efficiencies: up to 18.5 SEER/13 EER/9.5 HSPF
+                           Nominal Sizes 2, 3, 4 & 5 Ton
+                           [70.3, 10.6, 12.7 & 17.6 kW]
+                           Cooling Capacities 17.3 to 60.5 kBTU
+                           [5.7 to 17.7 kW]
+
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       18.5
+
+                                                  "Proper sizing and installation of equipment is critical to achieve optimal
+                                                   performance. Split system air conditioners and heat pumps must be
+                                                   matched with appropriate coil components to meet Energy Star.
+                                                   Ask your Contractor for details or visit www.energystar.gov."
+
+· EcoNet® Enabled product. The EcoNet Smart Home System              · Rust resistant screws - confirmed through 1500-hour salt
+   provides advanced air & water control for maximum energy             spray testing
+   savings and ideal comfort.
+                                                                     · PlusOne® Expanded Valve Space - 3"-4"-5" service valve
+· The inverter driven, variable speed compressor provides three         space - provides a minimum working area of 27-square
+   stages of heating and cooling operation for maximum comfort          inches for easier access
+   and energy savings. The overdrive feature in heating provides
+   heating down to 7°F.                                              · Integrated heat pump lift receptacle - allows standard CPVC
+                                                                        stands to be inserted into the base
+· Equipped with electronic expansion valve to precisely control
+   variable refrigerant flow.                                        · PlusOne® Triple Service Access - 15" wide, industry leading
+                                                                        corner service access - makes repairs easier and faster. The
+· New composite base pan - dampens sound, captures louver               two fastener removable corner allows optimal access to inter-
+   panels, eliminates corrosion and reduces number of fasteners         nal unit components. Individual louver panels come out once
+   needed                                                               fastener is removed, for faster coil cleaning and easier cabi-
+                                                                        net reassembly
+· Improved tubing design - reduces vibration and stress, mak-
+   ing unit quieter and reducing opportunity for leaks               · Diagnostic service window with two-fastener opening -
+                                                                        provides access to the TXV valves and the heat pump revers-
+· Optimized defrost characteristics - decrease defrosting and           ing valve before opening the unit.
+   provide better home comfort
+                                                                     · External gauge port access - allows easy connection of
+· Powder coat paint system - for a long lasting professional finish     "low-loss" gauge ports
+
+· Optimized reversing valve sizing - improves shifting perfor-       · Single-row condenser coil - makes unit lighter and allows thor-
+   mance for quieter unit operation and increased life of the           ough coil cleaning to maintain "out of the box" performance
+   system
+                                                                     · 35% fewer cabinet fasteners and fastener-free base - allow
+· Enhanced mufflers - help to dissipate vibration energy for            for faster access to internal components and hassle-free
+   quieter unit operation                                               panel removal
+
+· Modern cabinet aesthetics - increased curb appeal with visu-       · Service trays - hold fasteners or caps during service calls
+   ally appealing design
+                                                                     · QR code - provides technical information on demand for
+· Curved louver panels - provide ultimate coil protection,              faster service calls
+   enhance cabinet strength, and increased cabinet rigidity
+                                                                     · Fan motor harness with extra-long wires - allows unit top to
+· Optimized fan orifice - optimizes airflow and reduces unit            be removed without disconnecting fan wire
+   sound
+
+                                                                     FORM NO. P11-809 REV. 6
+         Table of Contents
+Air
+
+         RP17 Series
+
+                                         TABLE OF CONTENTS
+
+                          Standard Feature Table ............................................................................................3
+                          Available SKUs ........................................................................................................3
+                          Features & Benefits ..............................................................................................4-8
+                          Model Number Identification ..............................................................................9-10
+                          Physical Data ..........................................................................................................11
+                          Electrical Data ........................................................................................................11
+                          Accessories ............................................................................................................12
+                          Weighted Sound Power ..........................................................................................12
+                          Smart Home Systems ............................................................................................13
+                          Unit Dimensions......................................................................................................14
+                          Clearances ..............................................................................................................15
+                          Wiring Diagrams ....................................................................................................16
+                          Application Guidelines ............................................................................................16
+                          Refrigerant Line Size Information ......................................................................17-18
+                          Performance Data ..................................................................................................19
+                          Guide Specifications ..............................................................................................20
+                          Limited Warranty ....................................................................................................21
+
+2
+                                                                Standard Feature Table/Available SKUs
+                                                        Air
+
+                                                                RP17 Series
+
+Standard Feature Table                      24    36    48    60
+
+                                 Feature                      
+       R-410a Refrigerant
+       Maximum SEER                         18.5  17.5  17.0  17.0
+       Maximum EER
+       Maximum HSPF                         13.0  11.5  10.5  9.5
+       EcoNetTM Enabled
+       Electronic Expansion Valve           9.5   8.5   8.5   8.5
+       Variable Speed Compressor
+       Field Installed Filter Drier                           
+       Front Seating Service Valves
+       High Pressure Switch                                   
+       Low Pressure Transducer
+       Internal Pressure Relief Valve                         
+       Low Ambient capability
+       3-4-5 Service Valve Access                             
+       Composite Basepan
+       1 Screw Control Box Access                             
+       15" Access to Internal Components
+       Quick release louver panel design                      
+       No fasteners to remove along bottom
+       Optimized Venturi Airflow                              
+       Single row condenser coil
+       Powder coated paint                                    
+       Rust resistant screws
+       QR code                                                
+       External gauge ports
+       Service trays                                          
+ = Standard
+                                                              
+Available SKUs
+                                                              
+                 Available Models
+                  RP1724AJVCA                                 
+                  RP1736AJVCA
+                  RP1748AJVCA                                 
+                  RP1760AJVCA
+                                                              
+
+                                                              
+
+                                                              
+
+                                                              
+
+                                                              
+
+                                                              
+
+                                                              
+
+                                                              
+
+                                                                    3
+                  Features & Benefits                               Along with the EcoNet Smart Home System the RP17 is
+         Air                                                        matched with the RH2T Constant Torque Two-Stage EcoNet
+                                                                    Enabled Air Handler ( 3 ) or can be applied in a Dual Fuel appli-
+                  RP17 Series                                       cation with the EcoNet Enabled Two-Stage Variable Speed
+                                                                    R802V or R96V, or the modulating R97V Gas Furnaces and RCF
+Introduction to RP17 Heat Pump                                      Aluminum Cased Furnace Coils with EEV ( 4 ). See individual
+                                                                    specification documents for more details of the indoor products.
+The RP17 is our EcoNet® Enabled, inverter driven Classic Plus®
+Series Three-Stage Heat Pump and is part of the Rheem Heat              2
+Pump product line that extends from 13 to 20 SEER. This highly
+featured and reliable heat pump is designed for years of reliable,
+efficient operation when matched with Rheem indoor aluminum
+evaporator coils and furnaces or air handler units with aluminum
+evaporators.
+
+      WARNING: This product is not approved for installa-
+      tion at 2000 meters (6,561 feet) above sea level or
+      higher. Installation at higher altitudes may result in
+      control and unit failures due to electrical arc tracking
+      between electrical components on the invertor drive
+      control board possibly resulting in fire, electrical
+      shock, property damage, personal injury or death.
+
+The RP17 Classic Plus® Series inverter-driven Three-Stage Heat
+Pump is part of a new line of Rheem smart heating, cooling and
+water heating products. Using the latest in sensor technology
+and a powerful EcoNet® monitoring system, Rheem provides
+homeowners with a new level of protection, control and energy
+savings. Rheem smart heating, cooling and water heating prod-
+ucts will alert the homeowner if there is ever an issue via the
+EcoNet Smart Thermostat ( 1 ) and the EcoNet Mobile app. The
+EcoNet Mobile App makes it easy for homeowners to manage
+their home comfort environment at home or on-the-go*, while
+enjoying the convenience and savings benefits of a highly effi-
+cient system.
+
+   1
+
+                                                                    3
+
+*WiFi broadband internet connection required. Download the EcoNet App from the App Store or Google Play to set up your EcoNet Smart Thermostat.
+ Receipt of notifications depend on home WiFi set up. WiFi broadband internet connection required.
+
+       4
+                                                                                                  Features & Benefits
+                                                                                          Air
+
+                                                                                                  RP17 Series
+                                                                         5
+
+                                                            13
+                                      9
+
+                                                              14
+
+17
+
+                11      12                                        7
+
+                        8
+
+16                                                                   19
+
+                    18
+
+             6                              20
+10                      15
+
+How It Works                                                      wing fan technology ( 14 ) and the Electronic Expansion Valve
+                                                                  (EEV) ( 15 ) which syncs up with the compressor speed to deliver
+The RP17 Classic Plus® Series Inverter Driven Three-Stage Heat    the exact capacity the home needs to meet its comfort require-
+Pump's ( 5 ) variable speed outdoor unit control (VSODU) ( 6 )    ments. The result of this advanced technology is significantly
+continuously monitors the EcoNet control temperature and          improved energy efficiency and comfort. Energy efficiency is
+humidity set point, suction pressure ( 7 ), suction temperature   improved by precise load matching, less cycling on and off and
+( 8 ), outdoor coil temperature ( 9 ) and outdoor temperature     low amp gradual compressor, outdoor and indoor motor opera-
+( 10 ) and feeds this information to the Inverter Control Motor   tion. Comfort is improved by precise temperature control, pre-
+Drive ( 11 ). The Inverter Control Motor Drive converts AC to DC  cise humidity control and extra capacity during extreme cold
+power, sends it to the variable speed compressor ( 12 ) Brush-    weather conditions.
+less Permanent Magnet motor (BPM), dynamically adjusting its
+speed. Simultaneously the VSODU provides output to the out-
+door fan motor ( 13 ) which is equipped with the latest swept
+
+                                                                         5
+           Features & Benefits
+   Air
+
+           RP17 Series
+
+5                                                                      1
+
+                            9
+                                             14
+
+17
+
+                                12               7
+
+          11
+
+                           8
+
+      16                                                           19
+                   18                            20
+
+              6
+
+      10               15
+
+System Component Descriptions                                          The Electronic Expansion Valve (EEV) - ( 15 ) is an electroni-
+                                                                       cally driven refrigerant control valve. A small stepper motor is
+EcoNet Smart Thermostat - ( 1 ): The EcoNet Smart Thermo-              used to open and close valve to precisely control refrigerant
+stat serves as the hub of communication for a home's Heating,          flow. It is controlled by the VSODU, which receives input from
+Cooling and Water Heating systems and is required to operate           the pressure transducer and suction line temperature sensor to
+an EcoNet Enabled Heating and Cooling system in a fully com-           control the RP17 in the heating mode. The VSODU drives it fully
+municating mode. The EcoNet Smart Thermostat displays detail           open in the cooling mode. The EEV is superior to a TXV (ther-
+diagnostic from outdoor and indoor connected units.                    mostatic expansion valve) because the EEV controls superheat
+                                                                       at the evaporator coil under varying load and refrigerant flow
+Variable Speed Outdoor Unit Control (VSODU) - ( 6 ) is where           conditions, more precisely than traditional TXV's.
+control wiring is hooked to the RP17. The VSODU control takes
+input from the EcoNet Control Center, outdoor suction tempera-         The Filter - ( 16 ) is an electrical device that "cleans" the AC
+ture and pressure sensors, outdoor air and coil temperatures and       power component. This low pass filter only permits the passage
+communicates to the Inverter Control Motor Drive, EEV, reversing       of 60-Hertz signal to the inverter drive.
+valve, outdoor fan and indoor blower to precisely control system
+capacity output of the heat pump in heating and cooling modes.         The Pressure Transducer - ( 7 ) is used to measure suction
+It also is equipped with Dual Seven-Segment Display for techni-        pressure in the outdoor heat pump. The VSODU takes this input
+cian interface, operation status and fault code communication.         to operate the EEV and make decisions on system operation
+Two momentary buttons allow technician to initiate various oper-       such as low ambient cooling.
+ating modes. Various LED's communicate active EcoNet com-
+munication, microprocessor activity and EEV operation. See I&O         Various temperature sensors - are located on the Heat Pump.
+for more details.                                                      There is an outdoor air sensor ( 10 ), an outdoor coil sensor ( 9 ),
+                                                                       a discharge line temperature sensor (not shown, located on
+The Inverter Control Motor Drive - ( 11 ) converts incoming            discharge line), a suction line temperature sensor ( 8 ) and a
+single-phase AC power to 3 phase DC simulated sine wave                compressor sump temperature sensor (not shown, located bot-
+power. Once power is converted the Inverter Control Motor Drive        tom of compressor). The VSODU uses these temperature mea-
+varies frequency of the power to the compressor varying the            surements to operate the system.
+compressor speed. The Inverter Control Motor Drive has active
+protection algorithms that keep the compressor safely inside its       The Choke - ( 17 ) is provided to absorb power spikes that might
+operating envelope.                                                    occur on the DC line.
+
+The Variable Speed compressor - ( 12 ) utilizes a Brushless            Ferrite Rings - ( 18 ) are iron cores through which AC power is
+Permanent Magnet Motor (BPM) that varies the Scroll speed,             looped keeping any electrical noise contained. They also reduce
+thus, varying the refrigerant flow. The robust scroll design has       the induction of electrical transient into the DC drive.
+proven reliability over competing compressor technologies.
+                                                                       The Suction Accumulator - ( 19 ) prevents liquid refrigerant from
+Swept Wing Fan Blade - ( 14 ) is the latest technology in out-         entering the compressor.
+door fans that increase efficiency and reduces air noise.
+                                                                       The Reversing Valve - ( 20 ) reverses the flow of refrigerant in
+                                                                       cooling versus heating.
+
+   6
+Features                                                                                                                                                                 Features & Benefits
+                                                                                                                                                                Air
+In addition all RP17 Classic Plus Series Inverter Driven Three-
+Stage Heat Pumps have the following features:                                                                                                                            RP17 Series
+                                                                                                                                              18 20
+   3
+
+      4                                                                                                16
+                                                                                                                                                           17
+6        8
+   6        5       7
+
+Our unique composite base ( 3 ) reduces sound emission, elimi-                                         ( 17 ). Outdoor coil heights range from as short as 35" to 45".
+                                                                                                       Disassembly to this degree and complete reassembly only takes
+nates rattles, significantly reduces fasteners, eliminates corrosion                                   a first time service technician less than 10 minutes. ( 17 )
+and has integrated brass compressor attachment inserts ( 4 ).
+                                                                                                       All units utilize formed louver panels
+Furthermore it has incorporated into the design, water manage-
+ment features, means for hand placement ( 5 ) for unit maneu-                                          which provide industry leading coil
+
+vering, screw trays ( 6 ) and inserts for lifting off unit pad. ( 7 )                                  protection. Louver removal for coil                     19
+
+Service Valves ( 8 ) are rigidly mounted in the composite base                                         cleaning is accomplished by removing
+with 3" between suction and discharge valves, 4" clearance
+below service valves and a minimum of 5" above the service                                             one screw and lifting the panel out of
+valves, creating industry leading ease of installation. The minimum
+                                                                                                       the composite base pan. ( 19 ) All RP17
+
+                                                                                                       units utilize single row coils ( 18 )
+
+                                                                                                       making cleaning easy and complete,
+
+                                                                                                       restoring the performance of the air
+
+                                                                                                       conditioner back to out of the box
+
+            10  13                                                                                     performance levels year after year.
+
+      9                                                                                                The outdoor fan motor has ball bearings and is inherently pro-
+                                                                                                       tected. The motor is totally enclosed for maximum protection
+            12  11                                                                                     from weather, dust and corrosion. ( 20 ) Access to the outdoor fan
+                                                                                                       is made by removing four fasteners from the fan grille. The out-
+27 square-inches around the service valves allows ample room                                           door fan can be removed from the fan grille by removing 4 fas-
+to remove service valve schrader prior to brazing, plenty of clear-                                    teners in the rare case outdoor fan motor fails.
+ance for easy brazing of the suction and discharge lines to ser-
+vice valve outlets, easy access and hookup of low loss refriger-                                       Each cabinet has optimized composite ( 21 ) fan orifice assuring
+ant gauges ( 9 ), and access to the service valve caps for                                             efficient and quiet airflow.
+opening.
+                                                                                                                                                                   21
+Controls are accessed from the corner of the unit by removing
+only one fastener from the control access cover, revealing the                                         The entire cabinet has post powder paint ( 22 ) achieving 1000
+industry's largest 15" wide and 22" tall control area ( 10 ). With all                                 hour salt spray rating, allowing the cabinet to retain its aesthetics
+this room in the control area the high voltage electrical whip ( 11 )                                  throughout its life.
+can easily be inserted through the right size opening in the
+bottom of the control area. Routing it leads directly to lugs for                                                                                                              26
+connection. The low voltage control wires ( 12 ) are easily con-                                                                            22
+nected to the units VSODU terminal strip. The service window
+( 14 ) can be removed by removing two screws, to access the EEV                                                                                                           25
+and view interior of unit. ( 15 ) (High and low pressure is standard
+on RP17 models).                                                                                                                                              24
+                                                                                                                                                                           23
+               14
+                                                                                                       The Variable Speed compressors with standard internal pressure
+                                                                                                   15  relief and internal thermal overload are used on all capacities
+                                                                                                       assuring longevity of high efficient and quiet operation for the life
+If in the rare event, greater access is needed to internal compo-                                      of the product. All RP17 Heat Pump come standard with high
+nents, such as the compressor, the entire corner of the unit can                                       and low pressure controls reinforced vinyl compressor sound
+be removed along with the top cover assembly to have unprece-                                          covers containing a 11/2 inch thick batt of fiberglass insulation
+dented access to interior of the unit ( 16 ). Extra wire length is                                     and open edges are sealed with a 1 inch wide hook and loop
+incorporated into each outdoor fan and compressor so top                                               fastening tape for superior sound quality.
+cover and control panel can be positioned next to the unit. Or
+with minimal effort the plug can be removed from the compres-
+sor and the outdoor fan wires can be removed from the VSODU
+to allow even more uncluttered access to the interior of the unit
+
+                                                                                                                                                                       7
+                  Features & Benefits                                   Optional Accessories
+         Air
+                                                                        (Refer to accessory chart for model #)
+                  RP17 Series
+                                                                        3"/6"/12"
+Features (con't.)                                                       · Gray high density polyethylene feet are available to raise unit
+
+Each unit is shipped with filter drier for field installation and will    off of mounting surface away from moisture
+trap any moisture or dirt that could contaminate the refrigerant
+system.                                                                 Accessories
+
+                                     27                                 EcoNet Smart Thermostat
+
+All cabinets have industry leading structural strength due to the                                              The EcoNet Smart Thermostat
+composite base pan ( 23 ), interlocking corner post ( 24 ), formed                                             serves as the hub of communica-
+curved louver panels ( 25 ) and drawn top cover ( 26 ) making it                                               tion for a home's Heating, Cooling
+the most durable cabinet on the market today.                                                                  and Water Heating systems, and is
+Each RP17 capacity has undergone rigorous psychometric test-                                                   required to operate an EcoNet
+ing to assure performance ratings of capacity, SEER,                                                           Enabled Heating & Cooling system
+EER and HSPF per AHRI Standard 210/240 rating condi-                                                           in a fully communicating mode.
+tions. Also each unit bears the UL mark and each unit is
+certified to UL 1995 safety standards.                                            RETST700SYS
+Each unit has undergone specific strain and modal testing to
+assure tubing ( 27 ) is outside the units natural frequency and that
+the suction and discharge lines connected to the compressor
+withstand any starting, steady state operation, or shut down
+forces imposed by the compressor.
+All units have been sound tested in sound chamber to AHRI 270
+rating conditions, and A-weighted Sound Power Level tables
+produced, assuring units have acceptable noise qualities (see
+page 12). Each unit has been ran in cooling operation at 95°F
+and 47°F and sound ratings for the RP17 range from as low as
+67 dBA to 74.3 dBA.
+All units have been ship tested to assure units meet stringent
+"over the road" shipping conditions.
+As manufactured, all units in the RP17 family have cooling capa-
+bility to 40°F. Addition of low ambient control will allow the unit
+to operate down to 0°F. Factory testing is performed on each
+unit. All component parts meet well defined specification and
+continually go through receiving inspections. Each component
+installed on a unit is scanned, assuring correct component uti-
+lization for a given unit capacity and voltage. All condenser coils
+are leak tested with pressurization test to 550#'s and once
+installed and assembled, each units' complete refrigerant
+system is helium leak tested. All units are fully charged from the
+factory for up to 15 feet of piping. All units are factory run tested.
+The RP17 has a 10-year conditional unit replacement warranty
+(registration required) and a 10 year limited parts warranty.
+
+8
+Heat Pumps
+
+R      P                     17             24                      A               J                            V                      C                      A                *
+                                                                                                               Type                 Controls
+Brand     Product         SEER                      Capacity        Major Series*          Voltage          V - Inverter      C - Communicating                 Minor       Option
+Rheem     Category    20 - 20 SEER                   BTU/HR                         J - 1ph, 208-230/60                                                       Series**      Code
+                                                                    A - 1st Design
+       P - Heat Pump                        24 - 24,000 [7.03 kW]   B - 2nd Design                                                                          A - 1st Design   N/A
+                                            36 - 36,000 [10.55 kW]
+                                            48 - 48,000 [14.07 kW]
+                                            60 - 60,000 [17.58 kW]
+
+Air Conditioners (For Reference)
+
+R         A                        17           24                         A                   J                     2                      C               B                *
+                                                                    Major Series*
+Brand         Product            SEER               Capacity        A - 1st Design         Voltage                 Type                 Controls     Minor Series** Option Code
+Rheem        Category                            BTU/HR [kW]
+                             13 - 13 SEER                                           J - 1ph, 208-230/60     1 - Single-stage  C - Communicating      A - 1st Design          N/A
+       A - Air Conditioners  14 - 14 SEER   18 - 18,000 [5.28 kW]                   C - 3ph, 208-230/60     2 - Two-stage     N - Non-communicating
+                             16 - 16 SEER   24 - 24,000 [7.03 kW]                   D - 3ph, 460/60         V - Inverter
+                             17 - 17 SEER   30 - 30,000 [8.79 kW]
+                             20 - 20 SEER   36 - 36,000 [10.55 kW]
+                                            42 - 42,000 [12.31 kW]
+                                            48 - 48,000 [14.07 kW]
+                                            60 - 60,000 [17.58 kW]
+
+Furnace Coils (For Reference)
+
+R      C                     F                          24              17              S             E            A                 M               C            A                *
+                                                                                                            Major Series*       Orientation
+Brand    Product              Type                  Capacity          Width        Efficiency     Metering  A -1st Design     M - Multi-poise     Casing    Minor Series**   Option
+Rheem    Category                                    BTU/HR                                        Device                                                    A - 1st Design  Code
+                      F - Furn Coil         24 - 24,000 [7.03 kW]   14 - 14"    S- Standard Eff.  T-TXV                                        C - Cased
+       C - Evap Coil  H - Air-Handler Coil  36 - 36,000 [10.55 kW]  17 - 17.5"  M- Mid Eff.       E-EEV                                        U - Uncased                    N/A
+                                            48 - 48,000 [14.07 kW]  21 - 21"    H- High Eff.      P-Piston
+                                            60 - 60,000 [17.58 kW]  24 - 24.5"
+
+                                                                                                                                                                                                                                                                                                                                  Model Number Identification
+                                                                                                                                                                                                                                                                                                                                Air
+
+                                                                                                                                                                                                                                                                                                                              RP17 Series
+9
+[ ] Designates Metric Conversions
+90%+ AFUE Gas Furnaces (For Reference)
+
+                                                                                                                                                                                                                                                                                                                                  Model Number IdentificationR96VA702317MSA
+                                                                                                                                                                                                                                                                                                                                AirConfigurationMinor Rev
+Brand     Series              Motor         Major Rev                           Input              Stages                    Air Flow          Cabinet        M - Multi-poise          Nox            A - 1st Design
+                                                                                                                                                                                                                                                                                                                              RP17 SeriesRheemA - 1st DesignBTU/HR [kW]Width
+10     90 - 90 AFUE        V - Variable                                                       1 - Single-stage         3 - up to 3 ton         14 - 14"                           X - Low Nox
+       92 - 92 AFUE            speed                                040 - 42,000 [12.31 kW]   2 - Two-stage            5 - 3 1/2 up to 5 ton   17 - 17.5"                         S - Standard
+       95 - 95 AFUE                                                 060 - 56,000 [16.41 kW]   M - Modulating                                   21 - 21"
+       96 - 96 AFUE        T - Constant                             070 - 70,000 [20.51 kW]                                                    24 - 24.5"
+       97 - 97 AFUE           Torque                                085 - 84,000 [24.62 kW]
+                              (X-13)                                100 - 98,000 [28.72 kW]
+                                                                    115 - 112,000 [32.82 kW]
+                           P - PSC
+
+80% AFUE Gas Furnaces (For Reference)
+
+R         80                       2                         V                       A                   075                         3           17           M                               S            A
+
+Brand  Series              Stages                            Motor      Major Rev                       Input                    Air Flow        Cabinet         Configuration               Nox      Minor Rev
+                                                                                                   BTU/HR [kW]                                    Width
+Rheem  80 - 80+ AFUE    1 - Single-stage  V - Variable speed            A - 1st Design        050 - 50,000 [15 kW]        3 - up to 3 ton                     M - Multi                 X - Low Nox     A - 1st
+                        2 - Two-stage     T - Constant Torque (X-13)                          075 - 75,000 [22 kW]        4 - 2 1/2 to 4 ton     14 - 14"     D - Down                  S - Standard    Design
+                                          P - PSC premium                                     100 - 100,000 [29 kW]       5 - 3 1/2 up to 5 ton  17 - 17.5"   Z - Down &
+                                          S - PSC standard                                    125 - 125,000 [37 kW]                              21 - 21"
+                                                                                              150 - 150,000 [44 kW]                              24 - 24.5"       zero clearance
+                                                                                                                                                                  down flow
+
+Air Handlers (For Reference)
+
+R      H                2                 T                         36                  17    S                        E  A                                C                   A             A        000 *
+
+Brand      Product      Stages of        Motor Type                  Capacity        Width    Coil Size                Metering Major Series*    Controls                      Voltage        Minor Factory Option
+Rheem     Category       Airflow                                      BTU/HR                                            Device                                                               Series** Heat Cap Code
+
+       H - Air Handler  1 - Single-stage V - Variable Speed  24 - 24,000 [7.03 kW]   14 - 14" S - Standard Efficiency  T - TEV A -1st Design   C - Communicating A - 1ph, 115/60              A -1st 00 - no N/A
+                        2 - Two-stage T - Constant Torque    36 - 36,000 [10.55 kW]  17 - 17.5" M -Mid Efficiency      E - EEV                 N - Non-communicating J - 1ph, 208-240/60      Design factory
+                        M - Modulating P - PSC               48 - 48,000 [14.07 kW]  21 - 21" H - High Efficiency      P - Piston
+                                                             60 - 60,000 [17.58 kW]  24 - 24.5"                                                                             D - 3ph, 480/60              heat with
+                                                                                                                                                                                                         option
+                                                                                                                                                                                                         code
+
+[ ] Designates Metric Conversions
+                                                                                                                    Physical Data/Electrical Data
+                                                                                                            Air
+
+                                                                                                                    RP17 Series
+
+Physical Data                                                         RP1724        RP1736                  RP1748  RP1760
+                                                                        2.0           3.0                     4.0     5.0
+Model No.#
+Nominal Tonnage                              Liquid Line O.D. - in.     3/8         3/8                     3/8       3/8
+Valve Connections                          Suction Line O.D. - in.      3/4                                           7/8
+                                                                        130         3/4                     7/8       210
+Refrigerant (R410A) furnished oz.¹      Net face area - Outer Coil
+Compressor Type                         Net face area - Inner Coil      19.8        140                     209       28.3
+Outdoor Coil                                                             --                                            --
+                                               Tube diameter - in.      3/8                 Variable Speed            3/8
+Outdoor Fan                                        Number of rows         1                                             1
+                                                       Fins per inch     18         19.8                    24.2       20
+Shipping weight - lbs.
+Operating weight - lbs.                              Diameter - in.      24         --                      --         26
+                                                 Number of blades         2                                             3
+                                                                        1/6         3/8                     3/8       1/5
+                                                           Motor hp    3250                                          4280
+                                                                CFM    1075         1                       1         850
+                                                                RPM     167                                           187
+                                                               watts    230         20                      20        289
+                                                                        223                                           282
+                                                                                    24                      26
+
+                                                                                    2                       3
+
+                                                                                    1/6                     1/5
+
+                                                                                    3270                    4000
+
+                                                                                    910                     870
+
+                                                                                    145                     194
+
+                                                                                    230                     257
+
+                                                                                    223                     250
+
+Electrical Data
+
+Line Voltage Data (Volts-Phase-Hz)                                    208/230-1-60  208/230-1-60  208/230-1-60      208/230-1-60
+
+Minimum overcurrent protection (amps)²                                25            30                      35      50
+
+Maximum overcurrent protection (amps)²                                35            35                      45      60
+
+Minimum circuit ampacity³                                             21            22                      28      44
+
+Compressor
+
+                                        Rated load amps               16.0          16.3                    21.6    33.8
+
+                                        Locked rotor amps             35            35                      35      50
+
+Condenser Fan Motor
+
+                                        Full load amps                0.8           0.8                     1.0     1.0
+
+                                        Locked rotor amps             1.5           1.5                     1.5     2.4
+
+¹Refrigerant charge sufficient for 15 ft. length of refrigerant lines. For longer line set requirements see the installation instructions for information about set length and additional
+refrigerant charge required.
+²HACR type circuit breaker of fuse.
+³Refer to National Electrical Code manual to determine wire, fuse and disconnect size requirements.
+
+                                                                                                                          11
+        Accessories/Weighted Sound Power
+Air
+
+        RP17 Series
+
+Accessories
+
+             Model No.                          RP1724                                        RP1736            RP1748                                         RP1760
+                                                                                          RETST700SYS       RETST700SYS                                    RETST700SYS
+EcoNet Smart Thermostat   Solenoid Valve   RETST700SYS                                   Factory Standard  Factory Standard                               Factory Standard
+Compressor sound blanket  Solenoid Coil   Factory Standard                               Factory Standard  Factory Standard                               Factory Standard
+Low Ambient to 40         Bi-flow kit*    Factory Standard                               Factory Standard  Factory Standard                               Factory Standard
+Low pressure control      Solenoid Valve  Factory Standard                               Factory Standard  Factory Standard                               Factory Standard
+High pressure control     Solenoid Coil   Factory Standard                                200RD2T3TVLC      200RD3T3TVLC                                   200RD3T3TVLC
+                          Bi-flow kit*     200RD2T3TVLC
+Liquid Line Solenoid                                                                        61-AMG24V         61-AMG24V                                      61-AMG24V
+(24 VAC, 50/60 Hz)                           61-AMG24V                                        KS30387           KS30387                                        KS30387
+                                               KS30387
+Liquid Line Solenoid                                                                      200RD2T3TVLC      200RD3T3TVLC                                   200RD3T3TVLC
+(120/240 VAC, 50/60 Hz)                    200RD2T3TVLC                                  61-AMG120/240V    61-AMG120/240V                                 61-AMG120/240V
+                                          61-AMG120/240V
+Heat Pump Riser - 6 inch                                                                      KS30387           KS30387                                        KS30387
+                                               KS30387                                         686020            686020                                         686020
+                                                686020
+
+*Bi-flow kits are required when installing a liquid line solenoid on a heat pump.
+
+Weighted Sound Power Level (dBA)
+
+                                                                           RP17 Sound Power Level
+
+Model        Sound Power Level [dB(A)]                                                   Full Octave Linear Sound Power Level dB - Center Frequency - Hz
+
+             High Speed/Low Speed         125                                      250   500       1000    2000  4000        6300                         8000
+
+RP1724                    68.2            54.1                                     54.9  58.5      57.6    56.3  53.2        47.8                         44.1
+
+                          71.3            52.1                                     54.4  59.7      61.9    58.1  54.3        49.1                         48.3
+
+RP1736                    66.8            48.9                                     47.3  56.8      56.4    54    52.1        47.0                         44.5
+
+                          73.5            50.2                                     52.6  60.9      63.2    58.1  58.5        54.7                         58.1
+
+RP1748                    73.8            63.9                                     57.1  67.9      61.3    57.9  54.9        50.8                         48.6
+
+                          74.3            59.8                                     55.4  65.2      65.0    60.4  55.6        51.2                         49.5
+
+RP1760                    69.4            57.3                                     52.4  64.3      56.1    54.3  49.7        47.6                         44.4
+
+                          75.6            52.8                                     55.6  64.5      63.2    62.3  62.9        55.1                         52.0
+
+NOTE: Tested in accordance with AHRI Standard 270-08 (not listed in AHRI)
+
+12
+                                                                                                                           Smart Home Systems
+                                                                                                                   Air
+
+                                                                                                                           RP17 Series
+
+THE ECONET® SMART THERMOSTAT                                                                                       RETST700SYS
+
+BUILT-IN WIFI
+4.3 LCD TOUCH SCREEN
+LOCAL WEATHER - Current conditions plus 6-day forecast
+5 OPERATING MODES - Heat, Cool, Auto, Emergency Heat and Fan Only
+7-DAY PROGRAMMABLE SCHEDULE - Offers comfort without thought
+ONE-TOUCH AWAY - Quickly switch to your energy-saving away preferences
+VACATION SCHEDULING - Allows you to save while you're away and come home to comfort
+MOTION SENSOR - Automatically wakes the screen as you approach
+STANDBY SCREEN - Displays indoor temperature and current weather
+
+OPERATIONAL FEATURES
+
+AUTOMATIC CHANGEOVER - Transitions between heating and cooling automatically to keep the house comfortable
+INTEGRATED WATER CONTROL - Enables easy water heater management
+SMOOTH ARRIVAL - Prompts the system to start ahead of schedule to ensure the home is at the desired temperature at the scheduled time
+HUMIDITY CONTROL - Supports humidifier accessories or over-cool based dehumidification
+DETAILED OPERATING STATUS - View pertinent equipment status information and run times
+CONTINUOUS FAN - Offers 5 speeds (Low, Medium Low, Medium, Medium High, High)
+SHORT-CYCLE PROTECTION - Avoids damage to equipment from short run cycles
+
+MONITORING & REMOTE CONTROL FEATURES
+
+ACTIVE MONITORING - Alerts to problems that need immediate attention
+REMOTE CONTROL - Allows adjusting of comfort and settings from anywhere using a mobile device
+SERVICE ALERTS - Sends routine maintenance reminders
+AIR FILTER MONITORING - Detects when it's time to replace the air filter
+ALARM HISTORY - Displays time-stamped alarm codes with clear descriptions
+
+ECONET SMART THERMOSTAT COMPATIBILITY
+
+                                            Heating & Cooling
+
+     Models           Gas Furnaces                Air Handlers                                 Air Conditioners          Heat Pumps
+RETST700SYS
+             R802V  R96V  R97V        R98V  RHMV                RH2T                 RA20      RA17*               RP20              RP17
+                                        
+                                                                                                                                     
+
+                                                  *Models not EcoNet Enabled: RA1724AJ2NB, RA1736AJ2NB, RA1748AJ2NB, RA1760AJ2NB
+
+                                                                                                                                     13
+        Unit Dimensions
+Air
+
+        RP17 Series
+
+Unit Dimensions
+
+                                   OPERATING                              SHIPPING
+
+ MODEL  H (Height)                 L (Length)  W (Width)    H (Height)    L (Length)   W (Width)
+NUMBER
+        INCHES           mm    INCHES  mm      INCHES  mm   INCHES  mm    INCHES  mm   INCHES  mm
+RP1724
+RP1736  35               889   33.75   357     33.75   857  35.75   908   36.38   924  36.38   924
+RP1748
+RP1760  35               889   33.75   857     33.75   857  36.75   933   36.38   924  36.38   924
+
+        39               990   35.75   908     35.75   908  40.75   1035  38.38   974  38.38   974
+
+        45               1143  35.75   908     35.75   908  46.75   1187  38.38   974  38.38   974
+
+[ ] Designates Metric Conversions                                                      ST-A1226-02-00
+14
+    CLEARANCES                                                                                                                                                                                WALL
+
+                    WALL                                                                                                                                                                                     24
+                                                                                                                                                                                                          (609.6)
+                             6                                                                                                                                                                            Service
+                          (152.4)
+      24                                                                                                                                                                               12                                   WALL
+    (609.6)                 12                                                                                                                                                       (304.8)
+    Service               (304.8)
+
+                                                                                                                                                                                                                      6
+                                                                                                                                                                                                                   (152.4)
+
+                6
+             (152.4)
+
+                                                                                                                                                                                                12
+                                                                                                                                                                                              (304.8)
+
+               24                         WALL                                                                                                                                                  24
+             (609.6)                                                                                                                                                                          (609.6)
+             Service                         24                                                                                                                                               Service
+                                          (609.6)
+                                          Service
+
+      18                           24                       24
+    (457.2)                     (609.6)                  (609.6)
+
+                          24 recommended           24 recommended
+                          9 minimum                9 minimum
+
+    NOTE: NUMBERS IN () = mm                                                                                                                                                                                                           Clearances
+                                                                                                                                                                                                                                     Air
+    IMPORTANT: When installing multiple units in an alcove, roof well or partially enclosed area, ensure there is adequate ventillation to prevent re-circulation of discharge air.
+                                                                                                                                                                                                                                   RP17 Series
+15                                                                                                                                                                                                                 ST-A1225-01-00
+        Wiring Diagram/Application Guidelines
+Air
+
+        RP17 Series
+
+Control Wiring
+
+                TYPICAL ECONET SCMONATRRTOTLHECREMNTOESRTAHTOHOOKOUKPUP          TYPICAL 2-STAGE THERMOSTAT AND DUAL-FUEL
+                                                                                 APPLICATION
+
+                               Econet Control                                       Typical                   Fur nace                           (-)P17
+                                   Center                                        Two-Stage                    Contr ol                        Heat Pump
+                                                                                 Thermostat                                                  Outdoor Unit
+                Indoor         1 2RC                                   Outdoor
+                 Unit                                                    Unit                R                                                          RR
+                                                                                             C                R                                         C BR
+                    1 Y/PK                                         Y/PK 1                    Y                                                          YY
+                   2 O/W                                           O/W 2           (6) Y2                     C                                         Y2 Y/B L
+                                                                                            W2                                                          D PR
+                   RR                                               RR                                        YL
+                   C BR                                             BR C                             (5)                                                1 Y/PK
+                                                                                            W/E               YH                                        2 O/W
+                                                                                             G                                                          B BL
+                                                                                             V                W           PS  (3)
+                                                                                             B
+                               Line Voltage  F ield-Installed                                +                 G
+                                             Fa ctory Standard                               S                W2
+                                                                                             -
+                TYPICAL 2-STAGE THERMOSTAT: (-)P17 HEAT PUMP
+                WITH ELECTRIC HEAT USING A HUMIDISTAT                                       12 FT .           Outdoor
+                FOR DEHUMIDIFICATION                                                        (3.7 M )          Sensor (2)
+
+                               Typical Tw o-Stage Thermostat                     NOTES:
+
+                   Air                  B Y1 Y2 G E/W1 W2 C R DHM                (1) FOR PROGRAMMING THERMOST AT IN DUAL-FUEL APPLICA TION, SEE
+                Handler                                                            THERMOST AT INST ALLA TION INFORMA TION.
+
+                                                                       (-)P17    (2) FOR REMOTE SENSOR INST ALLA TION, SEE THERMOST AT INST ALLA TION INFORMA TION.
+                                                                    Heat Pump
+                W1 W/BK                                            Outdoor Unit  (3) OPTIONAL PLENUM SENSOR.
+
+                W2 W/BL                                                Y Y1      (4) FOR TWO ST AGES, CONNECT W2 ON THERMOST AT TO W2 ON THE CONTROL BOARD.
+                                                                     Y/BL Y2
+                                                                      BL B       (5) EMERGENCY HEA T (E) CONNECTION MA Y NOT BE ALLOWED BY LOCAL CODES.
+
+                Y1 Y                                                   RR        TY(6P)2-ISCT AAGELHE2AT-SPUTMAPOGNLEY. THERMOSTAT: HEAT PUMP WITH
+                                                                      BR C
+                Y2 Y/BL                                              W/R L
+                                                                      PR D
+                B BL
+
+                R           R
+
+                C BR                                                             TYPICAL TWO-STAGE THERMOSTAT: (-)P17 HEAT PUMP
+                                                                                 WITH ELECTRIC HEAT USING A HUMIDISTAT FOR
+                GG                                                               HUMIDIFICATION
+
+                ODD
+
+                     Line Voltage            F ield-Installed                                             Typical Tw o-Stage Thermostat
+                                             Fa ctory Standa rd
+                                                                                                                  B Y1 Y2 G E/W1 W2 C R Humidistat
+                TYPICAL 2-STAGE THERMOSTAT: (-)P17 HEAT PUMP                        Air
+                WITH ELECTRIC HEAT USING A TWO-STAGE                             Handler                                                                      (-)P17
+                THERMOSTAT WITH DEHUMIDIFICATION AND A                                                                                                    Heat Pump
+                MALFUNCTION LIGHT                                                        W1 W/BK                                                         Outdoor Unit
+
+                                                                                         W2 W/BL                                                                                 Y Y1
+                                                                                                                                                                               Y/BL Y2
+                                                                                         Y1 Y                                                                                   BL B
+
+                                                                                         Y2 Y/BL                                                                                 RR
+                                                                                                                                                                                BR C
+                                                                                         B BL                                                                                  W/R L
+                                                                                                                                                                                PR D
+                               Typical Tw o-Stage Thermostat                             R    R
+
+                                     B Y1 Y2 G E/W1 W2 C R DHM L                         C BR
+
+                   Air                                                                   GG
+                Handler
+                                                                       (-)P17            ODD
+                                                                    Heat Pump
+                W1 W/BK                                            Outdoor Unit
+
+                W2 W/BL                                                Y Y1                   Line Voltage    F ield-Installed
+                                                                     Y/BL Y2                                  Fa ctory Standa rd
+                Y1 Y                                                  BL B
+
+                Y2 Y/BL                                                RR
+                                                                      BR C
+                B BL                                                 W/R L
+                                                                      PR D
+                R           R                                                    TYPICAL TWO-STAGE THERMOSTAT: HEAT PUMP
+                                                                                 WITH ELECTRIC HEAT
+                C BR
+
+                GG
+
+                ODD                                                                                       Typical Tw o-Stage Thermostat
+
+                     Line Voltage                                                   Air                               B Y1 Y2 G E/W1 W2 C R
+                                                                                 Handler
+                                             F ield-Installed                                                                                    (-)P17
+                                             Fa ctory Standa rd                       W1 W/BK                                                 Heat Pump
+                                                                                      W2 W/BL                                                Outdoor Unit
+                *Add jumper between W1 and W2 for maximum                             Y1 Y
+                 temperature rise if desired.                                         Y2 Y/BL                                                    Y Y1
+                                                                                       B BL                                                    Y/BL Y2
+                                                                                       RR                                                       BL B
+                                                                                       C BR
+                                                                                       GG                                                        RR
+                                                                                                                                                BR C
+                                                                                        ODD                                                     W/R L
+                                                                                                                                                PR D
+
+                                                                                              Line Voltage    F ield-Installed
+                                                                                                              Fa ctory Standa rd
+
+Application Guidelines
+
+1. Intended for outdoor installation with free air inlet and outlet. Outdoor fan external static pressure available is less than 0.01 -in. wc.
+2. Minimum outdoor operation air temperature for cooling mode without low-ambient operation accessory is 55°F (12.8°C).
+3. Maximum outdoor operating air temperature is 125°F (51.7°C).
+4. For reliable operation, unit should be level in all horizontal planes.
+5. Use only copper wire for electric connections at unit. Aluminum and clad aluminum are not acceptable for the type of connector
+
+   provided.
+6. Do not apply capillary tube indoor coils to these units.
+7. Factory - supplied filter drier must be installed.
+
+16
+                                                                                                                                                                   Refrigerant Line Size Information
+                                                                                                                                                           Air
+
+                                                                                                                                                                   RP17 Series
+
+Table 2A: Refrigerant Line Sizing Chart (English Units)
+
+                                               17 SEER 3-Stage Heat Pumps
+
+           Allowable         Allowable                     Outdoor Unit ABOVE or BELOW Indoor Unit
+                                                                      Equivelent Length (Feet)
+Unit Size  Liquid Line       Vapor Line
+                                         < 25     26-50                    51-75                                                                  76-100   101-125  126-150
+           Size              Size
+
+                                                  Maximum Vertical Separation/Capacity Multiplier
+
+           1/4"              5/8"        25/0.99  50/0.98                  29/0.97                                                                0/0.97   N/R      N/R
+
+2.0 Ton    5/16"              5/8"       25/0.99  50/0.98                  50/0.97                                                                50/0.97  50/0.96  50/0.95
+ *SEE       3/8"              5/8"       25/0.99  50/0.98                  50/0.97                                                                50/0.97  50/0.96  50/0.95
+NOTE 3      1/4"             *3/4"*      25/1.00  50/1.00                  29/0.99                                                                0/0.99
+                             *3/4"*      25/1.00  50/1.00                  50/0.99                                                                50/0.99    N/R      N/R
+           5/16"                                                                                                                                           50/0.98  50/0.98
+
+           3/8"              *3/4"*      25/1.00  50/1.00                  50/0.99                                                                50/0.99  50/0.98  50/0.98
+
+           5/16"             5/8"        25/0.99  50/0.97                  50/0.95                                                                49/0.93  31/0.91  N/R
+
+           3/8"              5/8"        25/0.99  50/0.97                  50/0.95                                                                50/0.93  50/0.91  N/R
+
+3 Ton      5/16"             3/4"        25/1.00  50/0.99                  50/0.99                                                                49/0.98  31/0.97  14/0.96
+
+           3/8"              3/4"        25/1.00  50/0.99                  50/0.99                                                                50/0.98  50/0.97  50/0.96
+
+           1/2"              3/4"        25/1.00  50/0.99                  50/0.99                                                                50/0.98  50/0.97  50/0.96
+
+           3/8"              3/4"        25/0.99  50/0.98                  50/0.97                                                                50/0.95  50/0.94  50/0.92
+
+                       1/2"  3/4"        25/0.99  50/0.98                  50/0.97                                                                50/0.95  50/0.94  50/0.92
+4 Ton
+                             7/8"        25/1.00  50/0.99                  50/0.99                                                                50/0.98  50/0.98  50/0.97
+                       3/8"
+
+           1/2"              7/8"        25/1.00  50/0.99                  50/0.99                                                                50/0.98  50/0.98  50/0.97
+
+           3/8"              3/4"        25/0.99  50/0.96                  50/0.94                                                                50/0.92  N/R      N/R
+
+                       1/2"  3/4"        25/0.99  50/0.96                  50/0.94                                                                50/0.92  N/R      N/R
+5 Ton
+                             7/8"        25/1.00  50/0.99                  50/0.98                                                                50/0.97  45/0.96  30/0.95
+                       3/8"
+
+           1/2"              7/8"        25/1.00  50/0.99                  50/0.98                                                                50/0.97  50/0.96  50/0.95
+
+NOTES:                                                                                                                                                     [ ] Designates Metric Conversions
+1) Do not exceed 150 ft linear line length.
+2) Do not exceed 50 ft vertical separation between indoor and outdoor units.
+3) * 3/4" vapor line should only be used for 2 ton systems if outdoor unit is below or at same level as indoor unit to assure proper oil return.
+4) Always use the smallest liquid line allowable to minimize refrigerant charge.
+5) Applications shaded in light gray indicate capacity multipliers between 0.90 and 0.96 which are not recommended, but are allowed.
+6) Applications shaded in dark gray are not recommended due to excessive liquid or suction pressure drop.
+
+                                                                                                                                                                    17
+                Refrigerant Line Size Information
+        Air
+
+                RP17 Series
+
+Table 2B: Refrigerant Line Sizing Chart (Metric Units)
+
+                                                                                  17 SEER 3-Stage Heat Pumps
+
+            Allowable                           Allowable                                  Outdoor Unit ABOVE or BELOW Indoor Unit
+                                                                                                    Equivelent Length (Meters)
+Unit Size LiquSiidzeLine VapSoirzeLine < 8
+            mm [in.]                            mm [in.]                          8-15                        16-23                   24-30                    31-38    39-46
+
+                                                                                  Maximum Vertical Separation/Capacity Multiplier
+
+            6.35 [1/4]                          15.88 [5/8]  8/0.99               15/0.98                     9/0.97                  0/0.97                   N/R      N/R
+
+ 7.0 kW     7.94 [5/16]   15.88 [5/8]                        8/0.99               15/0.98                     15/0.97                 15/0.97                  15/0.96  15/0.95
+[2.0 Ton]   9.53 [3/8]    15.88 [5/8]                        8/0.99               15/0.99                     15/0.97                 15/0.97                  15/0.96  15/0.95
+            6.35 [1/4]   *19.05 [3/4]*                       8/1.00               15/0.99
+  *SEE      7.94 [5/16]  *19.05 [3/4]*                       8/1.00               15/0.99                      9/0.99                  0/0.99                    N/R      N/R
+NOTE 3                                                                                                        15/0.99                 15/0.99                  15/0.98  15/0.98
+
+            9.53 [3/8]   *19.05 [3/4]*                       8/1.00               15/0.99                     15/0.99                 15/0.99                  15/0.98  15/0.98
+
+            7.94 [5/16]                         15.88 [5/8]  8/0.99               15/0.97                     15/0.95                 15/0.93                  9/0.91   N/R
+
+10.6 kW     9.53 [3/8]                          15.88 [5/8]  8/0.99               15/0.97                     15/0.95                 15/0.93                  15/0.91    N/R
+[3 Ton]     7.94 [5/16]                         19.05 [3/4]  8/1.00               15/0.99                     15/0.99                 15/0.98                   9/0.97   4/0.96
+            9.53 [3/8]                          19.05 [3/4]  8/1.00               15/0.99                     15/0.99                 15/0.98                           15/0.96
+                                                                                                                                                               15/0.97
+
+            12.7 [1/2]                          19.05 [3/4]  8/1.00               15/0.99                     15/0.99                 15/0.98                  15/0.97  15/0.96
+
+            9.53 [3/8]                          19.05 [3/4]  8/0.99               15/0.98                     15/0.97                 15/0.95                  15/0.94  15/0.92
+
+14.1 kW     12.7 [1/2]                          19.05 [3/4]  8/0.99               15/0.98                     15/0.97                 15/0.95                  15/0.94  15/0.92
+[4 Ton]     9.53 [3/8]                          22.23 [7/8]  8/1.00               15/0.99                     15/0.99                 15/0.98                  15/0.98  15/0.97
+
+            12.7 [1/2]                          22.23 [7/8]  8/1.00               15/0.99                     15/0.99                 15/0.98                  15/0.98  15/0.97
+
+            9.53 [3/8]                          19.05 [3/4]  8/0.99               15/0.96                     15/0.94                 15/0.92                  N/R      N/R
+
+17.6 kW     12.7 [1/2]                          19.05 [3/4]  8/0.99               15/0.96                     15/0.94                 15/0.92                    N/R    N/R
+[5 Ton]     9.53 [3/8]                          22.23 [7/8]  8/1.00               15/0.99                     15/0.98                 15/0.97                  14/0.96  9/0.95
+
+            12.7 [1/2]                          22.23 [7/8]  8/1.00               15/0.99                     15/0.98                 15/0.97                  15/0.96  15/0.95
+
+NOTES:                                                                                                                                         [               ] Designates Metric Conversions
+
+1) Do not exceed 47 meters linear line length.
+
+2) Do not exceed 15 meters vertical separation between indoor and outdoor units.
+
+3) * 19.05mm [3/4 in.] vapor line should only be used for 2 ton systems if outdoor unit is below or at same level as indoor unit to assure proper oil return.
+
+4) Always use the smallest liquid line allowable to minimize refrigerant charge.
+
+5) Applications shaded in light gray indicate capacity multipliers between 0.90 and 0.96 which are not recommended, but are allowed.
+
+6) Applications shaded in dark gray are not recommended due to excessive liquid or suction pressure drop.
+
+        18
+Performance Data @ AHRI Standard Conditions - Heat Pump
+
+High Sales Volume Tested Combination (HSVTC)
+
+Outdoor    Air Handler             Total Capacity  Net Sensible  Net Latent   SEER                                       47 Degree                        47 Degree      17 Degree     47 Degree  Region
+  Unit                              BTU/H [kW]     BTU/H [kW]    BTU/H [kW]         EER Indoor CFM [L/s] Heating Capacity                                    COP     Heating Capacity     COP     IV HSPF
+                                                                              18.5
+                                                   17300 [5.1]    6700 [2.0]  17.5                                      BTU/H [kW]                           3.46       BTU/H [kW]        1.96       9.5
+                                                   26800 [7.9]    8400 [2.5]  17.0                                                                           3.76                         2.30       8.5
+RP1724AJV  RH2T2417SEAC            24000 [7.0]     34400 [10.1]  13600 [4.0]  17.0  13.0  750 [354.0]                                       24500 [7.2]      3.46      15600 [4.6]        2.20       8.5
+RP1736AJV  RH2T3617SEAC            35200 [10.3]    39400 [11.5]  19100 [5.6]                                                                                 3.30                         2.46       8.5
+RP1748AJV  RH2T4821MEAC            48000 [14.1]                                     11.5 1225 [578.1]                                       31000 [9.1]                19400 [5.7]
+RP1760AJV  RH2T6021SEAC            58500 [17.1]
+                                                                                    10.5 1400 [660.7]                                       46500 [13.7]               29000 [8.5]
+
+                                                                                    9.5 1575 [743.3]                                        62000 [18.2]               41500 [12.2]
+
+Note: Additional ratings and system match ups can be accessed on MyRheem.com at: https://my.rheem.com/static/private/ahriresidential.html
+Additional ratings and system match ups and downloadable ratings certificates can be accessed from the AHRI website: www.ahridirectory.org
+
+[ ] Designates Metric Conversions
+
+                                                                                                                                                                                                                                                                                                                                  Performance Data
+                                                                                                                                                                                                                                                                                                                                Air
+
+                                                                                                                                                                                                                                                                                                                              RP17 Series
+19
+        Guide Specifications
+Air
+
+        RP17 Series
+
+GUIDE SPECIFICATIONS                                                   AIR-COOLED, SPLIT-SYSTEM HEAT PUMP
+                                                                       RP17
+General                                                                1-1/2 TO 5 NOMINAL TONS
+                                                                       Fans
+System Description                                                     -- Condenser fan will be direct-drive propeller type, discharging
+Outdoor-mounted, air-cooled, split-system heat pump unit suit-
+able for ground or rooftop installation. Unit consists of a hermetic      air upward.
+compressor, composite basepan, an air-cooled coil, propeller-
+type condenser fan, suction and liquid line service valve, and a       -- Condenser fan motors will be totally enclosed, 1-phase type
+control box. Unit will discharge supply air upward as shown on            with class B insulation and permanently lubricated bearings.
+contract drawings. Unit will be used in a refrigeration circuit to        Shafts will be corrosion resistant.
+match up to a coil unit.
+                                                                       -- Fan blades will be statically and dynamically balanced.
+Quality Assurance
+-- Unit will be rated in accordance with the latest edition of AHRI    -- Condenser fan openings will be equipped with coated steel
+                                                                          wire safety guards.
+   Standard 210.
+                                                                       Compressor
+-- Unit will be certified for capacity and efficiency, and listed in   -- Compressor will be hermetically sealed.
+   the latest AHRI directory.
+                                                                       -- Compressor will be mounted on rubber vibration isolators.
+-- Unit construction will comply with latest edition of ANSI/
+   ASHRAE and with NEC.                                                Condenser Coil
+                                                                       -- Condenser coil will be air cooled.
+-- Unit will be constructed in accordance with UL standards and
+   will carry the UL label of approval. Unit will have c-UL-us         -- Coil will be constructed of aluminum fins mechanically bonded
+   approval.                                                              to copper tubes.
+
+-- Unit cabinet will be capable of withstanding ASTM B117 1000-        Refrigeration Components
+   hr salt spray test.                                                 -- Refrigeration circuit components will include liquid-line shutoff
+
+-- Air-cooled condenser coils will be leak tested at 150 psig and         valve with sweat connections, vapor-line shutoff valve with
+   pressure tested at 550 psig.                                           sweat connections, system charge of R-410A refrigerant, and
+                                                                          compressor oil.
+-- Unit constructed in ISO9001 approved facility.
+                                                                       -- Unit will be equipped with filter drier for R-410A refrigerant for
+Delivery, Storage, and Handling                                           field installation.
+-- Unit will be shipped as single package only and is stored and
+                                                                       Operating Characteristics
+   handled per unit manufacturer's recommendations.                    -- The capacity of the unit will meet or exceed _____ Btuh at a
+
+Warranty (for inclusion by specifying engineer) -- U.S. and               suction temperature of _____ °F/°C. The power consumption
+Canada only.                                                              at full load will not exceed _____ kW.
+
+Products                                                               -- Combination of the unit and the evaporator or fan coil unit will
+                                                                          have a total net cooling capacity of _____ Btuh or greater at
+Equipment                                                                 conditions of _____ CFM entering air temperature at the evap-
+Factory assembled, single piece, air-cooled heat pump unit. Con-          orator at _____ °F/°C wet bulb and _____ °F/°C dry bulb, and
+tained within the unit enclosure is all factory wiring, piping, con-      air entering the unit at _____ °F/°C.
+trols, compressor, refrigerant charge R-410A, and special fea-
+tures required prior to field start-up.                                -- The system will have a SEER of _____ Btuh/watt or greater at
+                                                                          DOE conditions.
+Unit Cabinet
+-- Unit cabinet will be constructed of galvanized steel, bonder-       Electrical Requirements
+                                                                       -- Nominal unit electrical characteristics will be _____ v, single
+   ized, and coated with a powder coat paint.
+                                                                          phase, 60 hz. The unit will be capable of satisfactory operation
+-- All units constructed with louver coil protection and corner post.     within voltage limits of _____ v to _____ v.
+   Louver can be removed by removing one fastener per louver
+   panel.                                                              -- Nominal unit electrical characteristics will be _____ v, three
+                                                                          phase, 60 hz. The unit will be capable of satisfactory operation
+                                                                          within voltage limits of _____ v to _____ v.
+
+                                                                       -- Unit electrical power will be single point connection.
+
+                                                                       -- Control circuit will be 24v.
+
+                                                                       Special Features
+                                                                       -- Refer to section of this literature identifying accessories and
+
+                                                                          descriptions for specific features and available enhancements.
+
+20
+                                                                                     Limited Warranty
+                                                                             Air
+
+                                                                                     RP17 Series
+
+GENERAL TERMS OF LIMITED WARRANTY*                                           Conditional Unit Replacement
+                                                                                (Registration Required) ...............................Ten (10) Years
+Rheem will furnish a replacement for any part of this product
+which fails in normal use and service within the applicable                  Parts ............................................................Ten (10) Years
+period stated, in accordance with the terms of the limited
+warranty.
+
+ *For complete details of the Limited and Conditional Warranties, including
+  applicable terms and conditions, contact your local contractor or the
+  Manufacturer for a copy of the product warranty certificate.
+
+                                                                             21
+         Notes
+Air
+
+         RP17 Series
+22
+        Notes
+Air
+
+        RP17 Series
+           23
+The new degree of comfort.TM
+
+In keeping with its policy of continuous progress and product improvement, Rheem reserves the right to make changes without notice.
+
+Rheem Heating, Cooling & Water Heating · 5600 Old Greenwood Road  Rheem Canada Ltd./Ltée · 125 Edgeware Road, Unit 1
+                 Fort Smith, Arkansas 72908 · www.rheem.com                         Brampton, Ontario · L6Y 0P5
+
+                                                                  PRINTED IN U.S.A. 11/19 QG FORM NO. P11-809 REV. 6
+

--- a/data/heat-pumps/rheem/classic-rp14/raw.txt
+++ b/data/heat-pumps/rheem/classic-rp14/raw.txt
@@ -1,0 +1,1050 @@
+                                                                                                                              Heat Pumps
+                                                                                                                      Air
+
+                                                                                                                              RP14 Series
+
+Rheem Classic® Series
+Heat Pump
+
+                       RP14 Series
+
+                           Efficiencies: 14 SEER/11.5 EER 8.2 HSPF
+                           Nominal Sizes 11/2 to 5 Ton [5.28 to 17.6 kW]
+                           Cooling Capacities 17.3 to 60.5 kBTU
+                           [5.7 to 17.7 kW]
+
+                                                  "Proper sizing and installation of equipment is critical to achieve
+                                                   optimal performance."
+
+· New composite base pan - dampens sound, captures louver            · Integrated heat pump lift receptacle - allows standard CPVC
+   panels, eliminates corrosion and reduces number of fasteners         stands to be inserted into the base
+   needed
+                                                                     · PlusOneTM Triple Service Access - 15" wide, industry lead-
+· Improved tubing design - reduces vibration and stress, mak-           ing corner service access - makes repairs easier and faster.
+   ing unit quieter and reducing opportunity for leaks                  The two fastener removable corner allows optimal access to
+                                                                        internal unit components. Individual louver panels come out
+· Optimized defrost characteristics - decrease defrosting and           once fastener is removed, for faster coil cleaning and easier
+   provide better home comfort                                          cabinet reassembly
+
+· Powder coat paint system - for a long lasting professional finish  · Diagnostic service window with two-fastener opening -
+                                                                        provides access to the TXV valves and the heat pump revers-
+· Optimized reversing valve sizing - improves shifting perfor-          ing valve before opening the unit.
+   mance for quieter unit operation and increased life of the
+   system                                                            · External gauge port access - allows easy connection of
+                                                                        "low-loss" gauge ports
+· Enhanced mufflers - help to dissipate vibration energy for
+   quieter unit operation                                            · Single-row condenser coil - makes unit lighter and allows thor-
+                                                                        ough coil cleaning to maintain "out of the box" performance
+· Scroll compressor - a sound abating feature added to the
+   compressor significantly reduces noise when system transi-        · 35% fewer cabinet fasteners and fastener-free base - allow
+   tions in and out of defrost mode                                     for faster access to internal components and hassle-free
+                                                                        panel removal
+· Modern cabinet aesthetics - increased curb appeal with visu-
+   ally appealing design                                             · Service trays - hold fasteners or caps during service calls
+
+· Curved louver panels - provide ultimate coil protection,           · QR code - provides technical information on demand for
+   enhance cabinet strength, and increased cabinet rigidity             faster service calls
+
+· Optimized fan orifice - optimizes airflow and reduces unit         · Fan motor harness with extra-long wires - allows unit top to
+   sound                                                                be removed without disconnecting fan wire
+
+· Rust resistant screws - confirmed through 1500-hour salt
+   spray testing
+
+· PlusOneTM Expanded Valve Space - 3"-4"-5" service valve
+   space - provides a minimum working area of 27-square
+   inches for easier access
+
+                                                                     FORM NO. P11-806 REV. 12
+         Table of Contents
+Air
+
+         RP14 Series
+
+                                         TABLE OF CONTENTS
+
+                          Standard Feature Table ............................................................................................3
+                          Available SKUs ........................................................................................................3
+                          Features & Benefits ..............................................................................................4-5
+                          Model Number Identification ................................................................................6-7
+                          Physical Data ............................................................................................................8
+                          Electrical Data ..........................................................................................................8
+                          Accessories ..............................................................................................................9
+                          Weighted Sound Power ............................................................................................9
+                          Unit Dimensions......................................................................................................10
+                          Clearances ..............................................................................................................11
+                          Wiring Diagrams ....................................................................................................12
+                          Application Guidelines ............................................................................................12
+                          Refrigerant Line Size Information ......................................................................13-16
+                          Performance Data ..................................................................................................17
+                          Guide Specifications ..............................................................................................18
+                          Limited Warranty ....................................................................................................19
+
+2
+                                                                       Standard Feature Table/Available SKUs
+                                                               Air
+
+                                                                       RP14 Series
+
+Standard Feature Table                 18    24    30    36    42                                         48    60
+
+                            Feature                                                                             
+  R-410a Refrigerant
+  Maximum SEER                         14    14    14    14    14                                         14    14
+  Maximum EER
+  Scroll Compressor                    11.5  11.5  11.5  11.5  11.5                                       11.5  11.5
+  Field Installed Filter Drier
+  Front Seating Service Valves                                                                                  
+  High Pressure Switch
+  Low Pressure Switch                                                                                           
+  Internal Pressure Relief Valve
+  Internal Thermal Overload                                                                                     
+  Long Line capability
+  Low Ambient capability with Kit                                                                               
+  3-4-5 Service Valve Access
+  Composite Basepan                                                                                             
+  2 Screw Control Box Access
+  15" Access to Internal Components                                                                             
+  Quick release louver panel design
+  No fasteners to remove along bottom                                                                           
+  Optimized Venturi Airflow
+  Single row condenser coil                                                                                     
+  Powder coated paint
+  Rust resistant screws                                                                                         
+  QR code
+  External gauge ports                                                                                          
+  Service trays
+ = Standard                                                                                                     
+
+Available SKUs                                                                                                  
+
+                 Available Models                                                                               
+                  RP1418CJ1NA
+                  RP1424AJ1NA                                                                                   
+                  RP1430AJ1NA
+                  RP1436AC1NA                                                                                   
+                  RP1436AD1NA
+                  RP1436AJ1NA                                                                                   
+                  RP1442CJ1NA
+                  RP1442CC1NA                                                                                   
+                  RP1442CD1NA
+                  RP1448AJ1NA                                                                                   
+                  RP1448AC1NA
+                  RP1448AD1NA                                                                                   
+                  RP1460BJ1NA
+                  RP1460BC1NA                                                                                   
+                  RP1460BD1NA
+                                                                                                                
+
+                                                                                                                
+
+                                                                                        Description
+                                       Classic ® 1 1/2 ton 14 SEER Single-Stage Heat Pump-208/230/1/60
+                                       Classic ® 2 ton 14 SEER Single-Stage Heat Pump-208/230/1/60
+                                       Classic ® 2 1/2 ton 14 SEER Single-Stage Heat Pump-208/230/1/60
+                                       Classic ® 3 ton 14 SEER Single-Stage Heat Pump-208/230/3/60
+                                       Classic ® 3 ton 14 SEER Single-Stage Heat Pump-460/3/60
+                                       Classic ® 3 ton 14 SEER Single-Stage Heat Pump-208/230/1/60
+                                       Classic ® 3 1/2 ton 14 SEER Single-Stage Heat Pump-208/230/1/60
+                                       Classic ® 3 1/2 ton 14 SEER Single-Stage Heat Pump-208/230/3/60
+                                       Classic ® 3 1/2 ton 14 SEER Single-Stage Heat Pump-460/3/60
+                                       Classic ® 4 ton 14 SEER Single-Stage Heat Pump-208/230/1/60
+                                       Classic ® 4 ton 14 SEER Single-Stage Heat Pump-208/230/3/60
+                                       Classic ® 4 ton 14 SEER Single-Stage Heat Pump-460/3/60
+                                       Classic ® 5 ton 14 SEER Single-Stage Heat Pump-208/230/1/60
+                                       Classic ® 5 ton 14 SEER Single-Stage Heat Pump-208/230/3/60
+                                       Classic ® 5 ton 14 SEER Single-Stage Heat Pump-460/3/60
+
+                                                                                                                  3
+                  Features & Benefits                                                  12
+         Air
+                                                                                                                                                                          13
+                  RP14 Series
+                                                                       If in the rare event, greater access is needed to internal compo-
+Introduction to RP14 Heat Pump                                         nents, such as the compressor, the entire corner of the unit can
+                                                                       be removed along with the top cover assembly to have unprece-
+The RP14 is our 14 SEER heat pump and is part of the Rheem             dented access to interior of the unit ( 14 ). Extra wire length is
+heat pump product line that extends from 14 to 20 SEER. This           incorporated into each outdoor fan and compressor so top cover
+highly featured and reliable heat pump is designed for years of        and control panel can be positioned next to unit. With minimal
+reliable, efficient operation when matched with Rheem indoor           effort the plug can be removed from the compressor and the
+aluminum evaporator coils and furnaces or air handler units with       outdoor fan wires can be removed from the capacitor to allow
+aluminum evaporators.                                                  even more uncluttered access to the interior of the unit ( 15 ).
+                                                                       Outdoor coils heights range from as short as 22" to 32", aiding
+Our unique composite base ( 1 ) reduces sound emission, elimi-         access to the compressor. Disassembly to this degree and com-
+nates rattles, significantly reduces fasteners, eliminates corrosion   plete reassembly only takes a first time service technician less
+and has integrated brass compressor attachment inserts ( 2 ).          than 10 minutes. ( 18 )
+Furthermore it has incorporated into the design, water manage-
+ment features, means for hand placement ( 3 ) for unit maneu-                                                                       16 18
+vering, screw trays ( 4 ) and inserts for lifting unit off pad. ( 5 )
+
+   1
+
+                                          2                            14      15
+          4
+                                                                       All units utilize strong formed louver panels which provide indus-
+                                  463 5                                try leading coil protection. Louver removal for coil cleaning is
+                                                                       accomplished by removing one screw and lifting the panel out
+Service valves ( 6 ) are rigidly mounted in the composite base         of the composite base pan ( 17 ). All RP14 units utilize single row
+with 3" between suction and discharge valves, 4" clearance             coils ( 16 ) making cleaning easy and complete, restoring the
+below service valves and a minimum of 5" above the service             performance of the heat pump back to out of the box perfor-
+valves, creating industry leading installation ease. The minimum       mance levels year after year.
+27-square inches around the service valves allows ample room
+to remove service valve schrader prior to brazing, plenty of clear-
+ance for easy brazing of the suction and discharge lines to ser-
+vice valve outlets, easy access and hookup of low loss refriger-
+ant gauges ( 7 ), and access to the service valve caps for
+opening. For applications with long-line lengths up to 250 feet
+total equivalent length, up to 200 feet heat pump above evapo-
+rator, or up to 80 feet evaporator above heat pump, the long-line
+instructions in the installation manual should be followed.
+
+      8  11
+
+   7                                                                       17
+
+                       9
+      10
+
+Controls are accessed from the corner of the unit by removing          The outdoor fan motor has sleeve bearings and is inherently
+only two fasteners from the control access cover, revealing the        protected. The motor is totally enclosed for maximum protection
+industry's largest 15" wide and 14" tall control area ( 8 ). With all  from weather, dust and corrosion. Access to the outdoor fan is
+this room in the control area the high voltage electrical whip ( 9 )   made by removing four fasteners from the fan grille. The outdoor
+can easily be inserted through the right size opening in the bot-      fan can be removed from the fan grille by removing 4 fasteners
+tom of the control area. Routing it leads directly to contractor       in the rare case outdoor fan motor fails.
+lugs for connection. The low voltage control wires ( 10 ) are easily
+connected to units low voltage wiring. If contactor defrost con-       Each cabinet has optimized composite ( 19 ) fan orifice assuring
+trol or capacitor ( 11 ) needs to be replaced there is more than       efficient and quiet airflow.
+adequate space to make the repair. Furthermore, the service
+window ( 12 ) can be removed to access the TXV and reversing                                                                                                                 19
+valve by removing two screws or the entire corner can be removed
+providing ultimate access to the TXV or reversing valve. ( 13 )
+
+4
+The entire cabinet has powder post paint ( 20 ) achieving 1000                                                                                                 Features & Benefits
+hour salt spray rating, allowing the cabinet to retain its aesthetics                                                                                 Air
+throughout its life.
+                                                                                                                                                               RP14 Series
+                                                                       24
+                                    20                                     All units have been ship tested to assure units meet stringent
+                                                                           "over the road" shipping conditions.
+                                                                  23
+                                                                           As manufactured all units in the RP14 family have cooling capa-
+                                                      22                   bility to 55 °F. Addition of low ambient control will allow the unit
+                                                                   21      to operate down to 0°F.
+
+Scroll compressors with standard internal pressure relief and              Factory testing is performed on each unit. All component parts
+internal thermal overload are used on all capacities assuring              meet well defined specification and continually go through
+longevity of high efficient and quiet operation for the life of the        receiving inspections. Each component installed on a unit is
+product. All RP14 Heat Pumps come standard with high and low               scanned, assuring correct component utilization for a given unit
+pressure switches.                                                         capacity and voltage. All condenser coils are leak tested with
+Each unit is shipped with filter drier for field installation and will     pressurization test to 550#'s and once installed and assembled,
+trap any moisture or dirt that could contaminate the refrigerant           each units' complete refrigerant system is helium leak tested. All
+system.                                                                    units are fully charged from the factory for up to 15 feet of pip-
+                                                                           ing. All units are factory run tested. The RP14 has a 10-year
+                                     25                                    conditional compressor and parts warranty (registration required).
+
+All cabinets have industry leading structural strength due to the          Optional Accessories (Refer to accessory chart for model #)
+composite base pan ( 21 ), interlocking corner post ( 22 ), formed
+curved louver panels ( 23 ) and drawn top cover ( 24 ) making it           Compressor Crankcase Heater
+the most durable cabinet on the market today.                              · Protects against refrigerant migration that can occur during
+Each RP14 capacity has undergone rigorous psychro-
+metric testing to assure performance ratings of                              low ambient operation
+capacity, SEER, EER and HSPF per AHRI Standard
+210/240 rating conditions. Also each unit bears the                        Compressor Sound Cover
+UL mark and each unit is certified to UL 1995 safety standards.            · Reinforced vinyl compressor cover containing a 1½ inch thick
+Each unit has undergone specific strain and modal testing to
+assure tubing ( 25 ) is outside the units natural frequency and that         batt of fiberglass insulation
+the suction and discharge lines connected to the compressor
+with stand any starting, steady state operation or shut down               · Open edges are sealed with a one-inch wide hook and loop
+forces imposed by the compressor.                                            fastening tape
+All units have been sound tested in sound chamber to AHRI 270
+rating conditions, and A-weighted Sound Power Level tables                 Compressor Hard Start Kit
+produced, assuring units have acceptable noise qualities (see              · Single-phase units are equipped with a PSC compressor
+page 9). Each unit has been ran in cooling operation at 95°F and
+47°F and sound ratings for the RP14 range from as low as 74                  motor. This type of motor normally does not need a potential
+dBA to 77 dBA.                                                               relay and start capacitor
+
+                                                                           · In conditions such as low voltage, this kit may be required to
+                                                                             increase the compressor starting torque
+
+                                                                           Low Ambient Kit
+                                                                           · Heat Pump operate satisfactorily in the cooling mode down to
+
+                                                                             55°F outdoor air temperature without any additional controls
+
+                                                                           · Kit can be added in the field enabling unit to operate properly
+                                                                             down to 0° in the cooling mode
+
+                                                                           · Crankcase heater and freezestat should be installed on com-
+                                                                             pressors equipped with a low ambient kit
+
+                                                                           3"/6"/12"
+                                                                           · Gray high density polyethylene feet are available to raise unit
+
+                                                                             off of mounting surface away from moisture
+
+                                                                           5
+Heat Pumps
+
+R                                                                                                                                                                                                                                                                                                                                 Model Number IdentificationP1424AJ1NA*
+                                                                                                                                                                                                                                                                                                                                Air
+
+                                                                                                                                                                                                                                                                                                                              RP14 Series
+6
+Brand  Product               SEER                   Capacity        Major Series*          Voltage                                                              Type                 Controls                  Minor      Option
+Rheem  Category                                      BTU/HR                                                                                               1 - Single-stage  N - Non-communicating            Series**     Code
+                                                                    A - 1st Design  J - 1ph, 208-230/60
+       P - Heat Pump 14 - 14 SEER           18 - 18,000 [5.28 kW]   B - 2nd Design  C - 3ph, 208-230/60                                                                                                   A - 1st Design   N/A
+                                            24 - 24,000 [7.03 kW]   C - 3rd Design  D - 3ph, 460/60                                                                                                       B - 2nd Design
+                                            30 - 30,000 [8.79 kW]
+                                            36 - 36,000 [10.55 kW]
+                                            42 - 42,000 [12.31 kW]
+                                            48 - 48,000 [14.07 kW]
+                                            60 - 60,000 [17.58 kW]
+
+Air Conditioners (For Reference)
+
+R         A                        14           24                         A                      J                                                                1                      N               A               *
+
+Brand         Product            SEER               Capacity        Major Series*             Voltage                                                            Type                 Controls     Minor Series** Option Code
+Rheem        Category                            BTU/HR [kW]
+                             13 - 13 SEER                           A - 1st Design     J - 1ph, 208-230/60                                                1 - Single-stage  C - Communicating      A - 1st Design         N/A
+       A - Air Conditioners  14 - 14 SEER   18 - 18,000 [5.28 kW]   B - 2nd Design     C - 3ph, 208-230/60                                                2 - Two-stage     N - Non-communicating
+                             16 - 16 SEER   24 - 24,000 [7.03 kW]                      D - 3ph, 460/60                                                    V - Inverter
+                             17 - 17 SEER   30 - 30,000 [8.79 kW]                                                                                                                                  B - 2nd Design
+                             20 - 20 SEER   36 - 36,000 [10.55 kW]
+                                            42 - 42,000 [12.31 kW]
+                                            48 - 48,000 [14.07 kW]
+                                            60 - 60,000 [17.58 kW]
+
+Furnace Coils (For Reference)
+
+R      C                     F              24                      17              S                                                                  T         A                 M               C            A               *
+                                                                                                                                                                              Orientation
+Brand    Product              Type                  Capacity          Width        Efficiency     Metering                                                Major Series*     M - Multi-poise     Casing    Minor Series**  Option
+Rheem    Category                                    BTU/HR                                        Device                                                                                                                 Code
+                      F - Furn Coil                                 14 - 14"    S- Standard Eff.                                                          A -1st Design                      C - Cased    A -1st Design
+       C - Evap Coil  H - Air-Handler Coil  24 - 24,000 [7.03 kW]   17 - 17.5"  M- Mid Eff.       T-TXV                                                   B -2nd Design                      U - Uncased  B -2nd Design    N/A
+                                            36 - 36,000 [10.55 kW]  21 - 21"    H- High Eff.      E-EEV
+                                            48 - 48,000 [14.07 kW]  24 - 24.5"                    P-Piston
+                                            60 - 60,000 [17.58 kW]
+
+Note: The above Model Number ID's are for reference only. Available SKU's are listed on the standard features/available SKU page of model spec sheet.
+
+[ ] Designates Metric Conversions
+90%+ AFUE Gas Furnaces (For Reference)
+
+R         96                     V          A                          70                       2                                                         3                      17                 M                    S              A
+
+Brand     Series            Motor          Major Rev                     Input              Stages                                                           Air Flow         Cabinet        Configuration              NOx        Minor Rev
+Rheem                                                               BTU/HR [kW]                                                                                                Width
+       92 - 92 AFUE      V - Variable    A - 1st Design                                1 - Single-stage                                                3 - up to 3 ton                       M - Multi-poise       X - Low NOx   A - 1st Design
+       95 - 95 AFUE          speed       B - 2nd Design      040 - 42,000 [12.31 kW]   2 - Two-stage                                                   5 - 3 1/2 up to 5 ton  14 - 14"       U - Upflow            S - Standard  B - 2nd Design
+       96 - 96 AFUE                                          060 - 56,000 [16.41 kW]   M - Modulating                                                                         17 - 17.5"     K - Downflow
+       97 - 97 AFUE      T - Constant                        070 - 70,000 [20.51 kW]                                                                                          21 - 21"
+       98 - 98 AFUE         Torque                           085 - 84,000 [24.62 kW]                                                                                          24 - 24.5"
+                            (X-13)                           100 - 98,000 [28.72 kW]
+                                                             115 - 112,000 [32.82 kW]
+
+80% AFUE Gas Furnaces (For Reference)
+
+R         80                     2                 V                       A                      075                                                                3               17        M                   S                   A
+
+Brand  Series            Stages                    Motor               Major Rev                 Input                                                           Air Flow        Cabinet          Configuration    NOx           Minor Rev
+                                                                                            BTU/HR [kW]                                                                           Width
+Rheem  80 - 80+ AFUE  1 - Single-stage   V - Variable speed            A - 1st Design  050 - 50,000 [15 kW]                                               3 - up to 3 ton                      M - Multi           X - Low NOx A - 1st Design
+                      2 - Two-stage                                                    075 - 75,000 [22 kW]                                               4 - 2 1/2 to 4 ton     14 - 14"      D - Down            S - Standard B - 2nd Design
+                                         T - Constant Torque (X-13) B - 2nd Design     100 - 100,000 [29 kW]                                              5 - 3 1/2 up to 5 ton  17 - 17.5"    Z - Down &
+                                                                                       125 - 125,000 [37 kW]                                                                     21 - 21"
+                                                                                       150 - 150,000 [44 kW]                                                                     24 - 24.5"        zero clearance
+                                                                                                                                                                                                   down flow
+
+Air Handlers (For Reference)
+
+R      H              1                  T                   36               17       S                                                               T     A                            N                   A    A             000 *
+
+Brand  Product        Stages of        Motor Type            Capacity      Width       Coil Size         Metering Major Series*                                                      Controls     Voltage           Minor Factory Option
+       Category        Airflow                               BTU/HR                                       Device                                                                                                   Series** Heat Cap Code
+
+Rheem H - Air Handler 1 - Single-stage V - Variable Speed 24 - 24,000 [7.03 kW] 14 - 14" S - Standard Efficiency T - TEV A -1st Design C - Communicating A - 1ph, 115/60                                           A -1st 00 - no N/A
+
+                 2 - Two-stage T - Constant Torque 36 - 36,000 [10.55 kW] 17 - 17.5" M -Mid Efficiency E - EEV B -2nd Design N - Non-communicating J - 1ph, 208-240/60 Design factory
+
+                 M - Modulating P - PSC            48 - 48,000 [14.07 kW] 21 - 21" H - High Efficiency P - Piston                                                                              D - 3ph, 480/60     B -2nd heat with
+
+                                                   60 - 60,000 [17.58 kW] 24 - 24.5"                                                                                                                               Design option
+
+                                                                                                                                                                                                                                 code
+
+Note: The above Model Number ID's are for reference only. Available SKU's are listed on the standard features/available SKU page of model spec sheet.
+
+[ ] Designates Metric Conversions
+
+                                                                                                                                                                                                                                                                                                                                  Model Number Identification
+                                                                                                                                                                                                                                                                                                                                Air
+
+                                                                                                                                                                                                                                                                                                                              RP14 Series
+7
+        Physical Data/Electrical Data
+Air
+
+        RP14 Series
+
+Physical Data                                            RP1418  RP1424  RP1430  RP1436    RP1442    RP1448    RP1460
+                                                           1.5     2.0     2.5     3.0       3.5       4.0       5.0
+  Model No.#
+  Nominal Tonnage                                          3/8     3/8     3/8     3/8       3/8       3/8       3/8
+  Valve Connections                                        3/4     3/4     3/4     3/4       7/8       7/8       7/8
+                                                           123      89     106     111       149       143       232
+                               Liquid Line O.D. - in.                             Scroll
+                             Suction Line O.D. - in.      11.14    9.1     11.1              19.8      19.8      24.2
+  Refrigerant (R410A) furnished oz.¹                        --      --      --     14.8       --        --        --
+  Compressor Type                                          3/8     3/8     3/8      --       3/8       3/8       3/8
+  Outdoor Coil                                               1       1       1     3/8         1         1         1
+                          Net face area - Outer Coil        20      20      20       1        20        20        20
+                          Net face area - Inner Coil                                20
+                                                            20      20      20                24        24        26
+                                 Tube diameter - in.         2       2       3      24         2         3         3
+                                     Number of rows        1/8     1/8     1/8       3       1/5       1/5       1/5
+                                         Fins per inch    2478    2410    2535     1/6      3376      4055      4780
+                                                          1077    1077    1077    3335       825       825       850
+  Outdoor Fan                                              151     156     142     825       161       228       279
+                                       Diameter - in.      159     152     208     173       228       234       269
+                                                           152     145     201     187       221       227       262
+                                   Number of blades                                187
+                                             Motor hp
+                                                   CFM
+                                                  RPM
+                                                  watts
+
+  Shipping weight - lbs.
+  Operating weight - lbs.
+
+Electrical Data                                          208/230-1-60 208/230-1-60 208/230-1-60 208/230-1-60 208/230-1-60 208/230-1-60 208/230-1-60
+
+Line Voltage Data (Volts-Phase-Hz)
+
+Maximum overcurrent protection (amps)²                   20/20   20      30      35        45        50        50
+
+Minimum circuit ampacity³                                12/12   14      19      22        24        29        31
+
+Compressor
+
+                           Rated load amps               9/9     10.3    14.1    16.7      21.4      21.8      23.7
+
+                           Locked rotor amps             48.0    61.6    73      79        123.9     117       152.5
+
+Condenser Fan Motor
+
+                           Full load amps                0.75    0.8     0.8     0.8       1         1.2       1.4
+
+                           Locked rotor amps             1.3     1.5     1.5     1.5       1.8       2.2       2.8
+
+Line Voltage Data (Volts-Phase-Hz)                       --      --      --      208/230-3-60 208/230-3-60 208/230-3-60 208/230-3-60
+
+   Maximum overcurrent protection (amps)²                --      --      --      20        30        30        35
+
+                     Minimum circuit ampacity³           --      --      --      14        18        19        22
+
+Compressor
+
+                           Rated load amps               --      --      --      10.4      15.1      13.7      15.9
+
+                           Locked rotor amps             --      --      --      73        88        83.1      110
+
+Condenser Fan Motor
+
+                           Full load amps                --      --      --      0.8       1         1.2       1.4
+
+                           Locked rotor amps             --      --      --      1.5       1.8       2.2       2.8
+
+Line Voltage Data (Volts-Phase-Hz)                       --      --      --      460-3-60  460-3-60  460-3-60  460-3-60
+
+   Maximum overcurrent protection (amps)²                --      --      --      15        15        15        15
+
+                     Minimum circuit ampacity³           --      --      --      8         9         9         10
+
+Compressor
+
+                           Rated load amps               --      --      --      5.8       6.6       6.2       7.1
+
+                           Locked rotor amps             --      --      --      38        44        41        52
+
+Condenser Fan Motor
+
+                           Full load amps                --      --      --      .5        .5        .6        .5
+
+                           Locked rotor amps             --      --      --      1.1       1.3       1.5       1.4
+
+¹Refrigerant charge sufficient for 15 ft. length of refrigerant lines. For longer line set requirements see the installation instructions for information about set length and additional
+refrigerant charge required.
+²HACR type circuit breaker of fuse.
+³Refer to National Electrical Code manual to determine wire, fuse and disconnect size requirements.
+
+8
+                                                                                                                               Accessories/Weighted Sound Power
+                                                                                                                       Air
+
+                                                                                                                               RP14 Series
+
+Accessories
+
+         Model No.                         RP1418                  RP1424               RP1430            RP1436            RP1442            RP1448            RP1460
+                                                                                     44-17402-44       44-17402-44       44-17402-45       44-17402-45     Factory Standard
+Compressor crankcase heater                44-17402-44       44-17402-44               RXAD-A08          RXAD-A08          RXAD-A08          RXAD-A08
+                                                                                     68-23427-26       68-23427-26       68-23427-25       68-23427-25         RXAD-A08
+Low ambient control                        RXAD-A08                RXAD-A08                                                                                  68-23427-25
+                                                                                         SK-A1             SK-A1             SK-A1             SK-A1
+Compressor sound cover                     68-23427-26       68-23427-26           Factory Standard  Factory Standard  Factory Standard  Factory Standard        SK-A1
+                                                                                   Factory Standard  Factory Standard  Factory Standard  Factory Standard  Factory Standard
+Compressor hard start kit                  SK-A1                   SK-A1            200RD2T3TVLC      200RD2T3TVLC      200RD2T3TVLC      200RD3T3TVLC     Factory Standard
+                                                                                                                                                            200RD3T3TVLC
+Low pressure control*      Solenoid Valve  Factory Standard  Factory Standard         61-AMG24V         61-AMG24V         61-AMG24V         61-AMG24V
+High pressure control*     Solenoid Coil   Factory Standard  Factory Standard           KS30387           KS30387           KS30387           KS30387         61-AMG24V
+                           Bi-flow kit*     200RD2T3TVLC      200RD2T3TVLC                                                                                      KS30387
+Liquid Line Solenoid       Solenoid Valve                                           200RD2T3TVLC      200RD2T3TVLC      200RD2T3TVLC      200RD3T3TVLC
+(24 VAC, 50/60 Hz)         Solenoid Coil      61-AMG24V         61-AMG24V          61-AMG120/240V    61-AMG120/240V    61-AMG120/240V    61-AMG120/240V     200RD3T3TVLC
+                           Bi-flow kit*         KS30387           KS30387                                                                                  61-AMG120/240V
+Liquid Line Solenoid                                                                    KS30387           KS30387           KS30387           KS30387
+(120/240 VAC, 50/60 Hz)                     200RD2T3TVLC      200RD2T3TVLC           91-101123-21      91-101123-21      91-101123-21      91-101123-21         KS30387
+                                           61-AMG120/240V    61-AMG120/240V                                                                                  91-101123-21
+Classic Top Cap w/Label                                                                  686020            686020            686020            686020
+Heat Pump Riser                                 KS30387           KS30387                                                                                        686020
+                                             91-101123-21      91-101123-21
+
+                                                 686020            686020
+
+*Bi-flow kits are required when installing a liquid line solenoid on a heat pump.
+
+Weighted Sound Power Level (dBA)
+
+VoUltnaigteS,iSzeer-ies Standard Rating (dBA) 125                                  TYPICAL OCTAVE BAND SPECTRUM (dBA without tone adjustment)
+
+                                                                                   250   500         1000              2000              4000              8000
+                                                                                                                                                            52
+RP1418C                      76.4                            53.7                  61.8  66.2        66.8              62.9              58                 53
+                                                                                                                                                           53.1
+RP1424A                      75                              55.9                  59.8  64.8        66.1              62.3              57.7              53.7
+                                                                                                                                                           50.7
+RP1430A                      77                              60.8                  60.5  65.4        66.9              63.9              59.9              52.9
+                                                                                                                                                           56.4
+RP1436A                      74                              50.5                  58    63.5        65.1              61.2              56.1
+
+RP1442C                      72                              47.6                  52.5  61.6        63.5              58.3              54.8
+
+RP1448A                      77                              53.4                  54.3  64.2        65.5              60.8              57.2
+
+RP1460B                      73.9                            58.9                  55.7  63.4        63.3              61.5              58.6
+
+NOTE: Tested in accordance with AHRI Standard 270-08 (not listed in AHRI)
+
+                                                                                                                                                           9
+        Unit Dimensions
+Air
+
+        RP14 Series
+
+Unit Dimensions
+
+                                   OPERATING                               SHIPPING
+
+ MODEL    H (Height)               L (Length)   W (Width)    H (Height)    L (Length)   W (Width)
+NUMBER
+          INCHES         mm        INCHES  mm   INCHES  mm   INCHES  mm    INCHES  mm   INCHES  mm
+RP1418CJ
+RP1424AJ  25.16          639       29.75   756  29.75   756  26.5    673   32.38   822  32.38   822
+RP1430AJ
+RP1436AC  25.16          639       29.75   756  29.75   756  26.5    673   32.38   822  32.38   822
+RP1442CJ
+RP1442CC  25.16          639       29.75   756  29.75   756  26.5    673   32.38   822  32.38   822
+RP1442CD
+RP1448AJ  27.16          690       33.75   857  33.75   857  28.5    724   36.38   924  36.38   924
+RP1460BD
+RP1460BJ  35.16          893       33.75   857  33.75   857  36.5    927   36.38   924  36.38   924
+
+          35.16          893       33.75   857  33.75   857  36.5    927   36.38   924  36.38   924
+
+          35.16          893       33.75   857  33.75   857  36.5    927   36.38   924  36.38   924
+
+          35.16          893       33.75   857  33.75   857  36.5    927   36.38   924  36.38   924
+
+          45.17          1147      35.75   908  35.75   908  46.5    1181  38.38   975  38.38   975
+
+          45.17          1147      35.75   908  35.75   908  46.5    1181  38.38   975  38.38   975
+
+[ ] Designates Metric Conversions                                                       ST-A1226-02-00
+       10
+    CLEARANCES                                                                                                                                                                                WALL
+
+                    WALL                                                                                                                                                                                     24
+                                                                                                                                                                                                          (609.6)
+                             6                                                                                                                                                                            Service
+                          (152.4)
+      24                                                                                                                                                                               12                                   WALL
+    (609.6)                 12                                                                                                                                                       (304.8)
+    Service               (304.8)
+
+                                                                                                                                                                                                                      6
+                                                                                                                                                                                                                   (152.4)
+
+                6
+             (152.4)
+
+                                                                                                                                                                                                12
+                                                                                                                                                                                              (304.8)
+
+               24                         WALL                                                                                                                                                  24
+             (609.6)                                                                                                                                                                          (609.6)
+             Service                         24                                                                                                                                               Service
+                                          (609.6)
+                                          Service
+
+      18                           24                       24
+    (457.2)                     (609.6)                  (609.6)
+
+                          24 recommended           24 recommended
+                          12 minimum               12 minimum
+
+    NOTE: NUMBERS IN () = mm                                                                                                                                                                                                           Clearances
+                                                                                                                                                                                                                                     Air
+    IMPORTANT: When installing multiple units in an alcove, roof well or partially enclosed area, ensure there is adequate ventillation to prevent re-circulation of discharge air.
+                                                                                                                                                                                                                                   RP14 Series
+11                                                                                                                                                                                                                 ST-A1225-01-00
+                  Wiring Diagram/Application Guidelines        Heat Pump Thermostat  TYPICAL THERMOSTAT:                 NOTES:
+         Air                                                                         HEAT PUMP WITH                      1. Jumper "E" to "W2" to
+                                                         B Y G W2 E C R              ELECTRIC HEAT
+                  RP14 Series                                                                                               transfer control of
+                                                                                      Heat Pump                             supplemental heat to
+Control Wiring                                                                       Outdoor Unit                           1st stage when the
+                                                                                                                            emergency heat switch
+   FIGURE 4                                                                              Y                                  is on.
+                                                                                         B
+    CONTROL WIRING FOR AIR HANDLER                                                                                       2. This wire turns on heat
+                                                                                          C                                 for defrost, omit for most
+                                  Air Handler                                                                               economical operation.
+                                     W2 W/BL                                             R
+                                    G G/BK                                              D                                3. Wire with colored tracing
+                                    YY                                                                                      stripe.
+                                     W1 W/BK
+
+                                  B BL
+
+                              ODD G/Y
+
+                                      C BR
+                                    R R
+                                    Y
+
+    WIRING INFORMATION                                   NOTE: RED WIRE REQUIRED WITH RANCO DDL DEMAND DEFROST CONTROL.
+    Line Voltage
+
+       -Field Installed
+       -Factory Standard
+
+Application Guidelines
+
+1. Intended for outdoor installation with free air inlet and outlet. Outdoor fan external static pressure available is less than 0.01-in. wc.
+2. Minimum outdoor operation air temperature for cooling mode without low-ambient operation accessory is 55°F (12.8°C).
+3. Maximum outdoor operating air temperature is 125°F (51.7°C).
+4. For reliable operation, unit should be level in all horizontal planes.
+5. Use only copper wire for electric connections at unit. Aluminum and clad aluminum are not acceptable for the type of connector
+
+   provided.
+6. Do not apply capillary tube indoor coils to these units.
+7. Factory - supplied filter drier must be installed.
+
+12
+Heat Pump Refrigerant Line Size Information (English Units)
+
+                                                                     14 - 15 SEER Single-Stage Heat Pumps
+
+           Allowable    Allowable   Use Long Line Guidelines                                                                                    Outdoor Unit ABOVE or BELOW Indoor Unit
+           Liquid Line  Vapor Line    for Linear Line Lengths                                                                                              Equivelent Length (Feet)
+
+Unit Size      Size         Size    Greater Than Shown Below
+                                                 (Feet)
+
+                                    (-)P14-A/B  (-)P14-F/P     < 25  26-50  51-75                                                               76-100 101-125 126-150 151-175                      176-200     201-225     226-250
+                                                  (-)P15
+                                                                                                                                                Maximum Vertical Separation / Capacity Multiplier      NR          NR          NR
+                                                                                                                                                                                                   78 / 0.96   73 / 0.95   68 / 0.94
+           1/4"         5/8"        98          98             25 / 1.00 50 / 0.99 62 / 0.98 43 / 0.98 24 / 0.97 5 / 0.97                                   NR                                     100 / 0.96  100 / 0.95  100 / 0.94
+
+           5/16"        5/8"        78          78             25 / 1.00 50 / 0.99 75 / 0.98 98 / 0.98 93 / 0.97 88 / 0.97 83 / 0.96                                                                   NR          NR          NR
+                                                                                                                                                                                                   78 / 0.98   73 / 0.98   68 / 0.98
+1.5 Ton    3/8"         5/8"        57          57             25 / 1.00 50 / 0.99 75 / 0.98 100 / 0.98 100 / 0.97 100 / 0.97 100 / 0.96                                                           100 / 0.98  100 / 0.98  100 / 0.98
+
+*SEE       1/4"         *3/4"*      98          98             25 / 1.00 50 / 1.00 62 / 0.99 43 / 0.99 24 / 0.99 5 / 0.99                                   NR                                         NR          NR          NR
+                                                                                                                                                                                                   53 / 0.92   45 / 0.91   37 / 0.90
+NOTE 3                                                                                                                                                                                             95 / 0.92   93 / 0.91   90 / 0.90
+
+           5/16"        *3/4"*      78          78             25 / 1.00 50 / 1.00 75 / 0.99 98 / 0.99 93 / 0.99 88 / 0.99 83 / 0.99                                                                   NR          NR          NR
+                                                                                                                                                                                                   53 / 0.97   45 / 0.97   37 / 0.96
+           3/8"         *3/4"*      57          57             25 / 1.00 50 / 1.00 75 / 1.00 100 / 0.99 100 / 0.99 100 / 0.99 100 / 0.99                                                           95 / 0.97   93 / 0.97   90 / 0.96
+
+           1/4"         5/8"        n/a         n/a            25 / 0.99 50 / 0.98 21 / 0.97                                                    NR  NR  NR  NR                                         NR          NR          NR
+                                                                                                                                                                                                       NR          NR          NR
+           5/16"        5/8"        170         123            25 / 0.99 50 / 0.98 75 / 0.97 87 / 0.96 77 / 0.95 69 / 0.94 61 / 0.93                                                               25 / 0.96   13 / 0.95       NR
+                                                                                                                                                                                                   86 / 0.96   82 / 0.95   78 / 0.95
+2 Ton      3/8"         5/8"        113         82             25 / 0.99 50 / 0.98 75 / 0.97 100 / 0.96 100 / 0.95 100 / 0.94 98 / 0.93                                                                NR          NR          NR
+                                                                                                                                                                                                       NR          NR          NR
+           1/4"         3/4"        n/a         n/a            25 /1.00 50 / 1.00 21 / 0.99                                                     NR  NR  NR  NR                                         NR          NR          NR
+                                                                                                                                                                                                   72 / 0.94   67 / 0.93   61 / 0.93
+           5/16"        3/4"        170         123            25 /1.00 50 / 1.00 75 / 0.99 87 / 0.99 77 / 0.98 69 / 0.98 61 / 0.98                                                                100 / 0.94  100 / 0.93  100 / 0.93
+                                                                                                                                                                                                       NR          NR          NR
+           3/8"         3/4"        113         82             25 / 1.00 50 / 1.00 75 / 0.99 100 / 0.99 100 / 0.98 100 / 0.98 98 / 0.98                                                            72 / 0.98   67 / 0.98   61 / 0.97
+                                                                                                                                                                                                   100 / 0.98  100 / 0.98  100 / 0.97
+           5/16"        5/8"        128         103            25 / 0.99 50 / 0.98 75 / 0.96 70 / 0.94 59 / 0.93 48 / 0.91 36 / 0.90                                                               57 / 0.91   49 / 0.90       NR
+                                                                                                                                                                                                   100 / 0.91  100 / 0.90      NR
+2.5 Ton    3/8"         5/8"        85          68             25 / 0.99 50 / 0.98 75 / 0.96 100 / 0.94 98 / 0.93 94 / 0.91 90 / 0.90                                                              57 / 0.97   49 / 0.96   42 / 0.96
+                                                                                                                                                                                                   100 / 0.97  100 / 0.96  100 / 0.96
+           5/16"        3/4"        128         103            25 / 1.00 50 / 0.99 75 / 0.99 70 / 0.98 59 / 0.98 48 / 0.97 36 / 0.96
+
+           3/8"         3/4"        85          68             25 / 1.00 50 / 0.99 75 / 0.99 100 / 0.98 98 / 0.98 94 / 0.97 90 / 0.96
+
+           5/16"        5/8"        115         98             25 / 0.99 50 / 0.97 66 / 0.94 49 / 0.92 32 / 0.90                                        NR  NR
+
+           3/8"         5/8"        77          65             25 / 0.99 50 / 0.97 75 / 0.94 95 / 0.92 89 / 0.90                                        NR  NR
+
+           5/16"        3/4"        115         98             25 / 1.00 50 / 0.99 66 / 0.98 49 / 0.98 32 / 0.97 15 / 0.96                                  NR
+
+           3/8"         3/4"        77          65             25 / 1.00 50 / 0.99 75 / 0.98 95 / 0.98 89 / 0.97 84 / 0.96 78 / 0.95
+3 Ton 1/2" 3/4" 38 33 25 / 1.00 50 / 0.99 75 / 0.98 100 / 0.98 100 / 0.97 100 / 0.96 100 / 0.95
+
+           5/16"        7/8"        115         98             25 / 1.00 50 / 1.00 66 / 1.00 49 / 0.99 32 / 0.99 15 / 0.99                                  NR
+
+           3/8"         7/8"        77          65             25 / 1.00 50 / 1.00 75 / 1.00 95 / 0.99 89 / 0.99 84 / 0.99 78 / 0.98
+
+           1/2"         7/8"        38          33             25 / 1.00 50 / 1.00 75 / 1.00 100 / 0.99 100 / 0.99 100 / 0.99 100 / 0.98
+
+           3/8"         3/4"        67          93             25 / 0.99 50 / 0.98 75 / 0.97 88 / 0.96 80 / 0.95 72 / 0.94 65 / 0.92
+
+           1/2"         3/4"        33          47             25 / 0.99 50 / 0.98 75 / 0.97 100 / 0.96 100 / 0.95 100 / 0.94 100 / 0.92
+3.5 Ton                                                                                                                                                                                                                                                                                                                           Refrigerant Line Size Information
+                                                                                                                                                                                                                                                                                                                                Air7/8"93
+
+                                                                                                                                                                                                                                                                                                                              RP14 Series
+13
+           3/8"                     67                         25 / 1.00 50 / 1.00 75 / 0.99 88 / 0.99 80 / 0.99 72 / 0.98 65 / 0.97
+
+           1/2"         7/8"        33          47             25 / 1.00 50 / 1.00 75 / 0.99 100 / 0.99 100 / 0.99 100 / 0.98 100 / 0.97
+
+NOTES:
+1. Do not exceed 200 ft linear line length.
+2. Do not exceed 100 ft vertical separation if outdoor unit is above indoor unit.
+3. *3/4" suction line should only be used for 1.5 ton systems if outdoor unit is below or at same level as indoor to assure proper oil return.
+4. Always use the smallest liquid line allowable to minimize refrigerant charge.
+5. Applications shaded in light gray indicate capacity multipliers between 0.90 and 0.96 which are not recommended, but are allowed.
+6. Applications shaded in dark gray are not recommended due to excessive liquid or suction pressure drop.
+Heat Pump Refrigerant Line Size Information (English Units) (con't.)
+
+                                                               14 - 15 SEER Single-Stage Heat Pumps
+                                                                                                                                                                                                                                                                                                                                  Refrigerant Line Size Information
+                                                                                                                                                                                                                                                                                                                                AirUse Long Line Guidelines
+                                      for Linear Line Lengths
+                                                                                                                                                                                                                                                                                                                              RP14 Series
+14                                  Greater Than Shown Below
+           Allowable    Allowable                (Feet)                                                                                         Outdoor Unit ABOVE or BELOW Indoor Unit
+           Liquid Line  Vapor Line                                                                                                                         Equivelent Length (Feet)
+
+Unit Size      Size         Size    (-)P14-A/B  (-)P14-F/P       < 25       26-50     51-75                                                     76-100 101-125 126-150 151-175                      176-200    201-225                                                                                                                                             226-250
+  4 Ton                                           (-)P15
+  5 Ton        3/8"         3/4"                               25 / 0.99  50 / 0.98  75 / 0.96                                                  Maximum Vertical Separation / Capacity Multiplier      NR         NR                                                                                                                                                  NR
+               1/2"         3/4"                               25 / 0.99  50 / 0.98  75 / 0.96                                                                                                         NR         NR                                                                                                                                                  NR
+               3/8"         7/8"    87          0              25 / 1.00  50 / 0.99  75 / 0.99                                                  77 / 0.95 67 / 0.93 57 / 0.92 46 / 0.91            36 / 0.96   26 / 0.95                                                                                                                                           15 / 0.95
+               1/2"         7/8"                               25 / 1.00  50 / 0.99  75 / 0.99                                                                                                     100 / 0.96  99 / 0.95                                                                                                                                           97 / 0.95
+               3/8"         3/4"    42          0              25 / 0.99  50 / 0.97  75 / 0.94                                                  100 / 0.95 100 / 0.93 100 / 0.92 100 / 0.91            NR         NR                                                                                                                                                  NR
+               1/2"         3/4"                               25 / 0.99  50 / 0.97  75 / 0.94                                                                                                         NR         NR                                                                                                                                                  NR
+               3/8"         7/8"    87          0              25 / 1.00  50 / 0.99  75 / 0.98                                                  77 / 0.98 67 / 0.97 57 / 0.97 46 / 0.96                NR         NR                                                                                                                                                  NR
+               1/2"         7/8"                               25 / 1.00  50 / 0.99  75 / 0.98                                                                                                     95 / 0.94   92 / 0.93                                                                                                                                           89 / 0.92
+               3/8"        1-1/8"   42          0              25 / 1.01  50 / 1.01  75 / 1.00                                                  100 / 0.98 100 / 0.97 100 / 0.97 100 / 0.96            NR         NR                                                                                                                                                  NR
+               1/2"        1-1/8"                              25 / 1.01  50 / 1.01  75 / 1.00                                                                                                     95 / 0.99   92 / 0.99                                                                                                                                           89 / 0.98
+                                    0           0                                                                                               61 / 0.92 46 / 0.90    NR  NR
+
+                                    0           0                                                                                               100 / 0.92 100 / 0.90  NR  NR
+
+                                    0           0                                                                                               61 / 0.97 46 / 0.96 32 / 0.95 18 / 0.94
+
+                                    0           0                                                                                               100 / 0.97 100 /0.96 100 / 0.95 97 / 0.94
+
+                                    0           0                                                                                               61 / 1.00 46 / 0.99 32 / 0.99 18 / 0.99
+
+                                    0           0                                                                                               100 /1.00 100 / 0.99 100 / 0.99 97 / 0.99
+
+NOTES:
+1. Do not exceed 200 ft linear line length.
+2. Do not exceed 100 ft vertical separation if outdoor unit is above indoor unit.
+3. *3/4" suction line should only be used for 1.5 ton systems if outdoor unit is below or at same level as indoor to assure proper oil return.
+4. Always use the smallest liquid line allowable to minimize refrigerant charge.
+5. Applications shaded in light gray indicate capacity multipliers between 0.90 and 0.96 which are not recommended, but are allowed.
+6. Applications shaded in dark gray are not recommended due to excessive liquid or suction pressure drop.
+Heat Pump Refrigerant Line Size Information (Metric Units)
+
+                                                                  14 - 15 SEER Single-Stage Heat Pumps
+
+            Allowable    Allowable     Use Long Line Guidelines                                                                                               Outdoor Unit ABOVE or BELOW Indoor Unit
+           Liquid Line   Vapor Line       for Linear Line Length                                                                                                       Equivelent Length (Meters)
+
+Unit Size       Size         Size      Greater Than Shown Below     < 8       8-15      16-23                                                                 24-30  31-38  39-46     47-53             54-61      62-69      70-76
+             mm [in.]     mm [in.]                (Meters)
+ 5.3 KW                                                           8 / 1.00  15 / 0.99  19 / 0.98                                                                                                          NR         NR         NR
+[1.5 Ton]   6.35 [1/4]                           (-)P14-A/B       8 / 1.00  15 / 0.99  23 / 0.98  Maximum Vertical Separation / Capacity Multiplier                                                    24 / 0.96  22 / 0.95  21 / 0.94
+            7.94 [5/16]                                           8 / 1.00  15 / 0.99  23 / 0.98                                                                                                       30 / 0.96  30 / 0.95  30 / 0.94
+  *SEE      9.53 [3/8]   15.88 [5/8]   30                         8 / 1.00  15 / 1.00  19 / 0.99  13 / 0.98 7 / 0.97                                                        2 / 0.97  NR
+ NOTE 3     6.35 [1/4]                                            8 / 1.00  15 / 1.00  23 / 0.99                                                                                                          NR         NR         NR
+            7.94 [5/16]  15.88 [5/8]   24                         8 / 1.00  15 / 1.00  23 / 0.99  30 / 0.98 28 / 0.97 27 / 0.97 25 / 0.96                                                              24 / 0.98  22 / 0.98  21 / 0.98
+ 7.0 KW     9.53 [3/8]                                            8 / 0.99  15 / 0.98  6 / 0.97                                                                                                        30 / 0.98  30 / 0.98  30 / 0.98
+ [2 Ton]    6.35 [1/4]   15.88 [5/8]   17                         8 / 0.99  15 / 0.98  23 / 0.97  30 / 0.98 30 / 0.97 30 / 0.97 30 / 0.96
+            7.94 [5/16]                                           8 / 0.99  15 / 0.98  23 / 0.97                                                                                                          NR         NR         NR
+ 8.8 KW     9.53 [3/8]   19.05 [3/4]*  30                         8 / 1.00  15 / 1.00  6 / 0.99   13 / 0.99 7 / 0.99                                                        2 / 0.99  NR               16 / 0.92  14 / 0.91  11 / 0.90
+[2.5 Ton]   6.35 [1/4]                                            8 / 1.00  15 / 1.00  23 / 0.99                                                                                                       29 / 0.92  28 / 0.91  27 / 0.90
+            7.94 [5/16]  19.05 [3/4]*  24                         8 / 1.00  15 / 1.00  23 / 0.99  30 / 0.99 28 / 0.99 27 / 0.99 25 / 0.99
+10.6 KW     9.53 [3/8]                                            8 / 0.99  15 / 0.98  23 / 0.96                                                                                                          NR         NR         NR
+ [3 Ton]    7.94 [5/16]  19.05 [3/4]*  17                         8 / 0.99  15 / 0.98  23 / 0.96  30 / 0.99 30 / 0.99 30 / 0.99 30 / 0.99                                                              16 / 0.97  14 / 0.97  11 / 0.96
+            9.53 [3/8]                                            8 / 1.00  15 / 0.99  23 / 0.99                                                                                                       29 / 0.97  28 / 0.97  27 / 0.96
+12.3 KW     7.94 [5/16]  15.88 [5/8]   n/a                        8 / 1.00  15 / 0.99  23 / 0.99                                                              NR     NR     NR        NR
+[3.5 Ton]   9.53 [3/8]                                            8 / 0.99  15 / 0.97  20 / 0.94                                                                                                          NR         NR         NR
+            7.94 [5/16]  15.88 [5/8]   52                         8 / 0.99  15 / 0.97  23 / 0.94  27 / 0.96 23 / 0.95 21 / 0.94 19 / 0.93                                                                 NR         NR         NR
+            9.53 [3/8]                                            8 / 1.00  15 / 0.99  20 / 0.98                                                                                                       8 / 0.96   4 / 0.95      NR
+            7.94 [5/16]  15.88 [5/8]   35                         8 / 1.00  15 / 0.99  23 / 0.98  30 / 0.96 30 / 0.95 30 / 0.94 30 / 0.93                                                              26 / 0.96  25 / 0.95  24 / 0.95
+            9.53 [3/8]                                            8 / 1.00  15 / 0.99  23 / 0.98                                                                                                          NR         NR         NR
+           12.70 [1/2]   19.05 [3/4]   n/a                        8 / 1.00  15 / 1.00  20 / 1.00                                                              NR     NR     NR        NR                  NR         NR         NR
+            7.94 [5/16]                                           8 / 1.00  15 / 1.00  23 / 1.00                                                                                                          NR         NR         NR
+            9.53 [3/8]   19.05 [3/4]   52                         8 / 1.00  15 / 1.00  23 / 1.00  27 / 0.99 23 / 0.98 21 / 0.98 19 / 0.98                                                              22 / 0.94  20 / 0.93  19 / 0.93
+           12.70 [1/2]                                            8 / 0.99  15 / 0.98  23 / 0.97                                                                                                       30 / 0.94  30 / 0.93  30 / 0.93
+            9.53 [3/8]   19.05 [3/4]   35                         8 / 0.99  15 / 0.98  23 / 0.97  30 / 0.99 30 / 0.98 30 / 0.98 30 / 0.98                                                                 NR         NR         NR
+           12.70 [1/2]                                            8 / 1.00  15 / 1.00  23 / 0.99                                                                                                       22 / 0.98  20 / 0.98  19 / 0.97
+            9.53 [3/8]   15.88 [5/8]   39                         8 / 1.00  15 / 1.00  23 / 0.99  21 / 0.94 18 / 0.93 15 / 0.91 11 / 0.90                                                              30 / 0.98  30 / 0.98  30 / 0.97
+           12.70 [1/2]                                                                                                                                                                                 17 / 0.91  15 / 0.90     NR
+                         15.88 [5/8]   26                                                         30 / 0.94 30 / 0.93 29 / 0.91 27 / 0.90                                                              30 / 0.91  30 / 0.90     NR
+                                                                                                                                                                                                       17 / 0.97  15 / 0.96  13 / 0.96
+                         19.05 [3/4]   39                                                         21 / 0.98 18 / 0.98 15 / 0.97 11 / 0.96                                                              30 / 0.97  30 / 0.96  30 / 0.96
+
+                         19.05 [3/4]   26                                                         30 / 0.98 30 / 0.98 29 / 0.97 27 / 0.96
+
+                         15.88 [5/8]   35                                                         15 / 0.92 10 / 0.90                                                       NR        NR
+
+                         15.88 [5/8]   23                                                         29 / 0.92 27 / 0.90                                                       NR        NR
+
+                         19.05 [3/4]   35                                                         15 / 0.98 10 / 0.97 5 / 0.96                                                        NR
+
+                         19.05 [3/4]   23                                                         29 / 0.98 27 / 0.97 26 / 0.96 24 / 0.95
+
+                         19.05 [3/4]   12                                                         30 / 0.98 30 / 0.97 30 / 0.96 30 / 0.95
+
+                         22.23 [7/8]   35                                                         15 / 0.99 10 / 0.99 5 / 0.99                                                        NR
+
+                         22.23 [7/8]   23                                                         29 / 0.99 27 / 0.99 26 / 0.99 24 / 0.98
+
+                         22.23 [7/8]   12                                                         30 / 0.99 30 / 0.99 30 / 0.99 30 / 0.98
+
+                         19.05 [3/4]   20                                                         27 / 0.96 24 / 0.95 22 / 0.94 20 / 0.92
+
+                         19.05 [3/4]   10                                                         30 / 0.96 30 / 0.95 30 / 0.94 30 / 0.92
+                                                                                                                                                                                                                                                                                                                                  Refrigerant Line Size Information
+                                                                                                                                                                                                                                                                                                                                Air22.23 [7/8]20
+
+                                                                                                                                                                                                                                                                                                                              RP14 Series
+15
+                                                                                                  27 / 0.99 24 / 0.99 22 / 0.98 20 / 0.97
+
+                         22.23 [7/8]   10                                                         30 / 0.99 30 / 0.99 30 / 0.98 30 / 0.97
+
+NOTES:
+1. Do not exceed 61 meters linear line length.
+2. Do not exceed 30 meters vertical separation if outdoor unit is above indoor unit.
+3. *19.05 mm [3/4 in.] suction line should only be used for 1.5 ton systems if outdoor unit is below or at same level as indoor to assure proper oil return.
+4. Always use the smallest liquid line allowable to minimize refrigerant charge.
+5. Applications shaded in light gray indicate capacity multipliers between 0.90 and 0.96 which are not recommended, but are allowed.
+6. Applications shaded in dark gray are not recommended due to excessive liquid or suction pressure drop.
+Heat Pump Refrigerant Line Size Information (Metric Units) (con't.)
+
+                                                                     14 - 15 SEER Single-Stage Heat Pumps
+                                                                                                                                                                                                                                                                                                                                  Refrigerant Line Size Information
+                                                                                                                                                                                                                                                                                                                                AirUse Long Line Guidelines
+                                        for Linear Line Length
+                                                                                                                                                                                                                                                                                                                              RP14 Series
+16                                   Greater Than Shown Below
+           Allowable    Allowable               (Meters)                                                                                                      Outdoor Unit ABOVE or BELOW Indoor Unit
+           Liquid Line  Vapor Line                                                                                                                                     Equivelent Length (Meters)
+                                               (-)P14-A/B
+Unit Size      Size         Size
+            mm [in.]     mm [in.]
+                                                                < 8       8-15       16-23                                                                    24-30  31-38      39-46      47-53        54-61      62-69                                                                                                                                            70-76
+
+                                                                                                Maximum Vertical Separation / Capacity Multiplier                                                         NR         NR                                                                                                                                               NR
+                                                                                                                                                                                                          NR         NR                                                                                                                                               NR
+           9.53 [3/8] 19.05 [3/4]    26                         8 / 0.99 15 / 0.98 23 / 0.96 24 / 0.95 20 / 0.93 17 / 0.92 14 / 0.91                                                                   11 / 0.96  8 / 0.95                                                                                                                                         5 / 0.95
+                                                                                                                                                                                                       30 / 0.96  30 / 0.95                                                                                                                                        30 / 0.95
+14.1 kW 12.7 [1/2] 19.05 [3/4]       13                         8 / 0.99  15 / 0.98  23 / 0.96  30 / 0.95                                                            30 / 0.93  30 / 0.92  30 / 0.91      NR         NR                                                                                                                                               NR
+                                                                8 / 1.00  15 / 0.99  23 / 0.99  24 / 0.98                                                            20 / 0.97  17 / 0.97  14 / 0.96      NR         NR                                                                                                                                               NR
+[4 Ton]    9.53 [3/8] 22.23 [7/8]    26                                                                                                                                                                   NR         NR                                                                                                                                               NR
+                                                                                                                                                                                                       29 / 0.94  28 / 0.93                                                                                                                                        27 / 0.92
+           12.7 [1/2] 22.23 [7/8]    13                         8 / 1.00 15 / 0.99 23 / 0.99 30 / 0.98 30 / 0.97 30 / 0.97 30 / 0.96                                                                      NR         NR                                                                                                                                               NR
+                                                                                                                                                                                                       29 / 0.99  28 / 0.99                                                                                                                                        27 / 0.98
+           9.53 [3/8] 19.05 [3/4]    0                          8 / 0.99 15 / 0.97 23 / 0.94 19 / 0.92 14 / 0.90                                                                NR         NR
+
+           12.7 [1/2] 19.05 [3/4]    0                          8 / 0.99 15 / 0.97 23 / 0.94 30 / 0.92 30 / 0.90                                                                NR         NR
+
+17.6 kW    9.53 [3/8] 22.23 [7/8]    0                          8 / 1.00  15 / 0.99  23 / 0.98  19 / 0.97                                                            14 / 0.96  10 / 0.95  5 / 0.94
+                                                                8 / 1.00  15 / 0.99  23 / 0.98  30 / 0.97                                                            30 /0.96   30 / 0.95  30 / 0.94
+[5 Ton] 12.7 [1/2] 22.23 [7/8]       0
+
+           9.53 [3/8] 28.58 [1-1/8]  0                          8 / 1.01 15 / 1.01 23 / 1.00 19 / 1.00 14 / 0.99 10 / 0.99 5 / 0.99
+
+           12.7 [1/2] 28.58 [1-1/8]  0                          8 / 1.01 15 / 1.01 23 / 1.00 30 / 1.00 30 / 0.99 30 / 0.99 30 / 0.99
+
+NOTES:
+1. Do not exceed 61 meters linear line length.
+2. Do not exceed 30 meters vertical separation if outdoor unit is above indoor unit.
+3. *19.05 mm [3/4 in.] suction line should only be used for 1.5 ton systems if outdoor unit is below or at same level as indoor to assure proper oil return.
+4. Always use the smallest liquid line allowable to minimize refrigerant charge.
+5. Applications shaded in light gray indicate capacity multipliers between 0.90 and 0.96 which are not recommended, but are allowed.
+6. Applications shaded in dark gray are not recommended due to excessive liquid or suction pressure drop.
+Performance Data @ AHRI Standard Conditions - Heat Pump
+
+Designated Tested Combination (DTC)
+
+Outdoor    Air Handler               Total Capacity  Net Sensible  Net Latent  SEER                                       47 Degree                        47 Degree      17 Degree     17 Degree  Region
+  Unit                                BTU/H [kW]     BTU/H [kW]    BTU/H [kW]        EER Indoor CFM [L/s] Heating Capacity                                    COP     Heating Capacity     COP     IV HSPF
+
+                                                                                                                         BTU/H [kW]                            3.6       BTU/H [kW]         2.4       8.2
+                                                                                                                                                               3.6       9100 [2.70]       2.34       8.2
+RP1418CJ1  RH1T2417STAN              18000 [5.3] 14000 [4.1] 3600 [1.1] 14 11.5      650 [306.8]                                            15700 [4.60]       3.5      12600 [3.70]       2.34       8.2
+                                                                                                                                                              3.66      16600 [4.90]       2.54        9
+RP1424AJ1  RH1T2417STAN              23800 [7.0] 17600 [5.2] 6200 [1.8] 14 11.5      825 [389.4]                                            22800 [6.70]      3.66      23200 [6.80]       2.54        9
+                                                                                                                                                              3.66      23200 [6.80]       2.54        9
+RP1430AJ1  RH1T3617STAN              28800 [8.4] 22200 [6.5] 6600 [1.9] 14 11.5 1050 [495.5]                                                27400 [8.00]       3.6      23200 [6.80]        2.5        9
+                                                                                                                                                               3.6      24800 [7.30]        2.5        9
+RP1436AC1  RH1T3617STAN              35200 [10.3] 26200 [7.7] 9000 [2.6] 14 11.5 1200 [566.3]                                               34800 [10.20]      3.6      24800 [7.30]        2.5        9
+                                                                                                                                                               3.6      24800 [7.30]        2.6        9
+RP1436AD1  RH1T3617STAN              35200 [10.3] 26200 [7.7] 9000 [2.6] 14 11.5 1200 [566.3]                                               34800 [10.20]      3.7      29800 [8.70]        2.6       8.5
+                                                                                                                                                               3.7      34600 [10.14]       2.6       8.5
+RP1436AJ1  RH1T3617STAN              35200 [10.3] 26200 [7.7] 9000 [2.6] 14 11.5 1200 [566.3]                                               34800 [10.20]               34600 [10.14]
+
+RP1442AC1  RH1T4821STAN              42500 [12.5] 32400 [9.5] 10100 [3.0] 14 11.5 1400 [660.7]                                              39000 [11.40]
+
+RP1442AD1  RH1T4821STAN              42500 [12.5] 32400 [9.5] 10100 [3.0] 14 11.5 1400 [660.7]                                              39000 [11.40]
+
+RP1442AJ1  RH1T4821STAN              42500 [12.5] 32400 [9.5] 10100 [3.0] 14 11.5 1400 [660.7]                                              39000 [11.40]
+
+RP1448AJ1  RH1T4821STAN              48000 [14.1] 35700 [10.5] 12300 [3.6] 14 11.5 1525 [719.7]                                             46000 [13.50]
+
+RP1460BC1  RH1T6024STAN              56500 [16.6] 40900 [12.0] 15600 [4.6] 14 11.5 1800 [849.5]                                             54500 [15.97]
+
+RP1460BJ1  RH1T6024STAN              56500 [16.6] 40900 [12.0] 15600 [4.6] 14 11.5 1800 [849.5]                                             54500 [15.97]
+
+Note: Additional ratings and system match ups can be accessed on MyRheem.com at: https://my.rheem.com/static/private/ahriresidential.html
+Additional ratings and system match ups and downloadable ratings certificates can be accessed from the AHRI website: www.ahridirectory.org
+
+[ ] Designates Metric Conversions
+
+                                                                                                                                                                                                                                                                                                                                  Performance Data
+                                                                                                                                                                                                                                                                                                                                Air
+
+                                                                                                                                                                                                                                                                                                                              RP14 Series
+17
+        Guide Specifications
+Air
+
+        RP14 Series
+
+GUIDE SPECIFICATIONS                                                   AIR-COOLED, SPLIT-SYSTEM HEAT PUMP
+                                                                       RP14
+General                                                                1-1/2 TO 5 NOMINAL TONS
+                                                                       Fans
+System Description                                                     -- Condenser fan will be direct-drive propeller type, discharging
+Outdoor-mounted, air-cooled, split-system heat pump unit suit-
+able for ground or rooftop installation. Unit consists of a hermetic      air upward.
+compressor, composite basepan, an air-cooled coil, propeller-
+type condenser fan, suction and liquid line service valve, and a       -- Condenser fan motors will be totally enclosed, 1-phase type
+control box. Unit will discharge supply air upward as shown on            with class B insulation and permanently lubricated bearings.
+contract drawings. Unit will be used in a refrigeration circuit to        Shafts will be corrosion resistant.
+match up to a coil unit.
+                                                                       -- Fan blades will be statically and dynamically balanced.
+Quality Assurance
+-- Unit will be rated in accordance with the latest edition of AHRI    -- Condenser fan openings will be equipped with coated steel
+                                                                          wire safety guards.
+   Standard 210.
+                                                                       Compressor
+-- Unit will be certified for capacity and efficiency, and listed in   -- Compressor will be hermetically sealed.
+   the latest AHRI directory.
+                                                                       -- Compressor will be mounted on rubber vibration isolators.
+-- Unit construction will comply with latest edition of ANSI/
+   ASHRAE and with NEC.                                                Condenser Coil
+                                                                       -- Condenser coil will be air cooled.
+-- Unit will be constructed in accordance with UL standards and
+   will carry the UL label of approval. Unit will have c-UL-us         -- Coil will be constructed of aluminum fins mechanically bonded
+   approval.                                                              to copper tubes.
+
+-- Unit cabinet will be capable of withstanding ASTM B117 1000-        Refrigeration Components
+   hr salt spray test.                                                 -- Refrigeration circuit components will include liquid-line shutoff
+
+-- Air-cooled condenser coils will be leak tested at 150 psig and         valve with sweat connections, vapor-line shutoff valve with
+   pressure tested at 550 psig.                                           sweat connections, system charge of R-410A refrigerant, and
+                                                                          compressor oil.
+-- Unit constructed in ISO9001 approved facility.
+                                                                       -- Unit will be equipped with filter drier for R-410A refrigerant for
+Delivery, Storage, and Handling                                           field installation.
+-- Unit will be shipped as single package only and is stored and
+                                                                       Operating Characteristics
+   handled per unit manufacturer's recommendations.                    -- The capacity of the unit will meet or exceed _____ Btuh at a
+
+Warranty (for inclusion by specifying engineer) -- U.S. and               suction temperature of _____ °F/°C. The power consumption
+Canada only.                                                              at full load will not exceed _____ kW.
+
+Products                                                               -- Combination of the unit and the evaporator or fan coil unit will
+                                                                          have a total net cooling capacity of _____ Btuh or greater at
+Equipment                                                                 conditions of _____ CFM entering air temperature at the evap-
+Factory assembled, single piece, air-cooled heat pump unit. Con-          orator at _____ °F/°C wet bulb and _____ °F/°C dry bulb, and
+tained within the unit enclosure is all factory wiring, piping, con-      air entering the unit at _____ °F/°C.
+trols, compressor, refrigerant charge R-410A, and special fea-
+tures required prior to field start-up.                                -- The system will have a SEER of _____ Btuh/watt or greater at
+                                                                          DOE conditions.
+Unit Cabinet
+-- Unit cabinet will be constructed of galvanized steel, bonder-       Electrical Requirements
+                                                                       -- Nominal unit electrical characteristics will be _____ v, single
+   ized, and coated with a powder coat paint.
+                                                                          phase, 60 hz. The unit will be capable of satisfactory operation
+-- All units constructed with louver coil protection and corner post.     within voltage limits of _____ v to _____ v.
+   Louver can be removed by removing one fastener per louver
+   panel.                                                              -- Nominal unit electrical characteristics will be _____ v, three
+                                                                          phase, 60 hz. The unit will be capable of satisfactory operation
+                                                                          within voltage limits of _____ v to _____ v.
+
+                                                                       -- Unit electrical power will be single point connection.
+
+                                                                       -- Control circuit will be 24v.
+
+                                                                       Special Features
+                                                                       -- Refer to section of this literature identifying accessories and
+
+                                                                          descriptions for specific features and available enhancements.
+
+18
+                                                                                     Limited Warranty
+                                                                             Air
+
+                                                                                     RP14 Series
+
+GENERAL TERMS OF LIMITED WARRANTY*                                           Conditional Parts
+                                                                                (Registration Required) ...............................Ten (10) Years
+Rheem will furnish a replacement for any part of this product
+which fails in normal use and service within the applicable
+period stated, in accordance with the terms of the limited
+warranty.
+
+ *For complete details of the Limited and Conditional Warranties, including
+  applicable terms and conditions, contact your local contractor or the
+  Manufacturer for a copy of the product warranty certificate.
+
+                                                                             19
+The new degree of comfort.TM
+
+In keeping with its policy of continuous progress and product improvement, Rheem reserves the right to make changes without notice.
+
+Rheem Heating, Cooling & Water Heating · 5600 Old Greenwood Road  Rheem Canada Ltd./Ltée · 125 Edgeware Road, Unit 1
+                 Fort Smith, Arkansas 72908 · www.rheem.com                         Brampton, Ontario · L6Y 0P5
+
+                                                                  PRINTED IN U.S.A. 4/20 QG FORM NO. P11-806 REV. 12
+

--- a/data/heat-pumps/rheem/endeavor-line-prestige-rp18az/golden.json
+++ b/data/heat-pumps/rheem/endeavor-line-prestige-rp18az/golden.json
@@ -1,0 +1,58 @@
+[
+  {
+    "modelNumber": "RP18AZ24AJVCA",
+    "tonnage": 2,
+    "weight": {
+      "value": 278,
+      "unit": "lb"
+    },
+    "electricBreakerSize": 30,
+    "voltage": 208,
+    "soundLevelMin": 65,
+    "soundLevelMax": 70,
+    "brandName": "Rheem",
+    "sourceUrl": "https://files.myRheem.com/webpartners/ProductDocuments/3552AAA5-F72D-44EA-A96A-7CFA6DF1D3F9.pdf"
+  },
+  {
+    "modelNumber": "RP18AZ36AJVCA",
+    "tonnage": 3,
+    "weight": {
+      "value": 298,
+      "unit": "lb"
+    },
+    "electricBreakerSize": 50,
+    "voltage": 208,
+    "soundLevelMin": 65,
+    "soundLevelMax": 70,
+    "brandName": "Rheem",
+    "sourceUrl": "https://files.myRheem.com/webpartners/ProductDocuments/3552AAA5-F72D-44EA-A96A-7CFA6DF1D3F9.pdf"
+  },
+  {
+    "modelNumber": "RP18AZ48AJVCA",
+    "tonnage": 4,
+    "weight": {
+      "value": 298,
+      "unit": "lb"
+    },
+    "electricBreakerSize": 60,
+    "voltage": 208,
+    "soundLevelMin": 65,
+    "soundLevelMax": 70,
+    "brandName": "Rheem",
+    "sourceUrl": "https://files.myRheem.com/webpartners/ProductDocuments/3552AAA5-F72D-44EA-A96A-7CFA6DF1D3F9.pdf"
+  },
+  {
+    "modelNumber": "RP18AZ60AJVCA",
+    "tonnage": 5,
+    "weight": {
+      "value": 301,
+      "unit": "lb"
+    },
+    "electricBreakerSize": 60,
+    "voltage": 208,
+    "soundLevelMin": 65,
+    "soundLevelMax": 70,
+    "brandName": "Rheem",
+    "sourceUrl": "https://files.myRheem.com/webpartners/ProductDocuments/3552AAA5-F72D-44EA-A96A-7CFA6DF1D3F9.pdf"
+  }
+]

--- a/data/heat-pumps/rheem/endeavor-line-prestige-rp18az/raw.txt
+++ b/data/heat-pumps/rheem/endeavor-line-prestige-rp18az/raw.txt
@@ -1,0 +1,579 @@
+                                                                                                                                                                                                                        Heat Pumps
+                                                                                                                                                                                                                        RP18AZ
+
+            Endeavor® Line Prestige® Series
+                           Heat Pumps
+
+                 RP18AZ
+
+                    Cooling Efficiencies up to: 20.0 SEER2/12.5 EER2
+                    Heating Efficiency: 8.5 HSPF2
+                    Nominal Sizes: 2 to 5 Ton [7.0 to 17.6 kW]
+                    Cooling Capacities 22.8 to 55.0 kBTU [6.7 to 16.1 kW]
+
+                                              *
+
+                                                                                                                                    19.0
+
+= A.F.U.E. (Annual Fuel Utilization Efficiency) calculated in accordance withDepartment of Energy test p­ rocedures.
+The Bluetooth® word mark and logos are registered trademarks owned by Bluetooth SIG, Inc. and any use of such marks by Rheem® is under license.
+
+                                                     Other trademarks and trade names are those of their respective owners.
+      *Proper sizing and installation of equipment is critical to achieve optimal performance. Split system air conditioners and heat pumps
+     must be matched with appropriate coil components to meet Energy Star. Ask your Contractor for details or visit www.energystar.gov.
+
+                                                                                                                                                                                                                                                                                                FORM NO. P11-823 REV. 3
+Table of Contents
+RP18AZ
+
+                                          Table of Contents
+
+                   Features & Benefits...................................................................3
+                   Model Number Identification.....................................................4
+                   General Data/Electrical Data.....................................................5
+                   Accessories...............................................................................6
+                   Unit Dimensions........................................................................7
+                   Clearances................................................................................8
+                   Refrigerant Line Size Information........................................ 9-10
+                   Capacity Ranges............................................................... 11-14
+                   Performance Data...................................................................15
+                   Smart Home Systems.............................................................16
+                   Limited Warranty.....................................................................20
+
+2
+Features and Benefits                                                                                                                           Features and Benefits
+                                                                                                                                                RP18AZ
+· EcoNet® Enabled: Automatic system configuration and
+   optimization                                                · Brushless DC Condenser Motors (BLDC): Enhances
+                                                                  reliability and allows for easier serviceability
+· PlusOne® Diagnostics & Bluetooth®1 Connectivity: With
+   the Rheem Contractor & EcoNet® Apps, built-in technology    · Swept Wing Fan Technology: Features quieter operation
+   makes advanced set-up, monitoring, troubleshooting, and        and improved unit acoustics
+   repairing the product easier than ever before
+
+· Variable Speed Scroll Compressor & Inverter Drive:
+   --F eatures variable speed operation from 40 to 100%
+      capacity with the EcoNet® Smart Thermostat
+
+   --O ffers overdrive capability up to 115% to maintain
+      performance in extreme conditions
+
+   --P rovides precise temperature control, advanced humidity
+      control and greater efficiency
+
+1The Bluetooth® word mark and logos are registered trademarks owned by Bluetooth SIG, Inc. and any use of such marks by Rheem® is under license.
+ Other trademarks and trade names are those of their respective owners.
+
+                                                                                                                                                                                                          3
+Model Number Identification
+RP18AZ
+
+ Heat Pumps
+
+   R              P              18      A                 Z         24                      A             J                  V                   N         A
+
+   Brand    Product           SEER2      Region Refrigerant          Capacity                Major Series  Voltage            Type                Controls  Minor Series
+            Category      18 - 18 SEER2
+
+R - Rheem P - Heat Pump                  A - All Regions Z - R-410A  24 - 24,000 [7.03 kW]   A - 1st Design J - 208/230/1/60  V - Fully Variable  C - Communicating A - 1st Design
+                                                                     36 - 36,000 [10.55 kW]
+                                                                     48 - 48,000 [14.07 kW]
+                                                                     60 - 60,000 [17.58 kW]
+
+[ ] Designates Metric Conversions
+
+            AVAILABLE MODELS                                                                             DESCRIPTION
+              RP18AZ24AJVCA                 Endeavor® Line Prestige ® Series 2 ton EcoNet® Enabled Inverter Driven Variable Speed iM Heat Pump - 208/230/1/60
+              RP18AZ36AJVCA                 Endeavor® Line Prestige ® Series 3 ton EcoNet® Enabled Inverter Driven Variable Speed iM Heat Pump - 208/230/1/60
+              RP18AZ48AJVCA                 Endeavor® Line Prestige ® Series 4 ton EcoNet® Enabled Inverter Driven Variable Speed iM Heat Pump - 208/230/1/60
+              RP18AZ60AJVCA                 Endeavor® Line Prestige ® Series 5 ton EcoNet® Enabled Inverter Driven Variable Speed iM Heat Pump - 208/230/1/60
+
+                                 STANDARD EQUIPMENT
+
+   R-410A Refrigerant
+
+   EcoNet® Enabled
+
+   Variable Speed Compressor
+
+   Compressor Sound Blanket
+
+   Variable speed outdoor fan motor                                                                                      R-410A Refrigerant
+                                                                                                                         Maximum SEER2: 16SEER2
+   Swept wing fan blade
+                                                                                                                                R-410A Refrigerant
+   Field Installed Filter Drier                                                                                                 Maximum SEER2: 16SEER2
+                                                                                                                                Maximum EER2: 11 EER2
+   Front Seating Service Valves                                                                                                 Maximum HSPF: 8 HSPF
+                                                                                                                                EcoNet Enabled Description
+   Internal Pressure Relief Valve                          EndeavorTM Line Prestige ® Series 2 ton EcoNet® Enabled InVvaerriatebrleDSripveendVCaorimabplereSsspoered Heat Pump - 208/230/1/60
+                                                           EndeavorTM Line Prestige ® Series 3 ton EcoNet® Enabled InCvoemrtperreDsrsiovrenSoVuanridabBlelaSnkpeeted Heat Pump - 208/230/1/60
+   Internal Thermal Overload             Available Models  EndeavorTM Line Prestige ® Series 4 ton EcoNet® Enabled InVvaerriatebrleDsrpiveeendVoaurtiadboloerSfapneemdoHtoear t Pump - 208/230/1/60
+   Low Ambient capability                RP18AZ24AJVCA     EndeavorTM Line Prestige ® Series 5 ton EcoNet® Enabled InSvweertpetrwDirnivgefnanVabrliaadbele Speed Heat Pump - 208/230/1/60
+   3-4-5 Expanded Valve Space                                                                                                   Field Installed Filter Drier
+                                                                                                                                Front Seating Service Valves
+   Composite Basepan                     RP18AZ36AJVCA                                                                          Internal Pressure Relief Valve
+   1" Screw Control Box Access           RP18AZ48AJVCA                                                                          Internal Thermal Overload
+   Quick release louver panel design     RP18AZ60AJVCA                                                                          Low Ambient capability
+   No fasteners to remove along bottom                                                                                          3-4-5 Expanded Valve Space
+                                                                                                                                Composite Basepan
+   Optimized Venturi Airflow                                                                                                    1" Screw Control Box Access
+                                                                                                                                15" Access to Internal Components
+   Single row condenser coil                                                                                                    Quick release louver panel design
+                                                                                                                                No fasteners to remove along bottom
+   Powder coated paint                                                                                                          Optimized Venturi Airflow
+                                                                                                                                Single row condenser coil
+   Rust resistant screws                                                                                                        Powder coated paint
+                                                                                                                                Rust resistant screws
+   QR code                                                                                                                      QR code
+                                                                                                                                External gauge ports
+   External gauge ports                                                                                                         Service trays
+
+   Service trays
+
+4
+                                                                                                       General Data/Electrical Data
+                                                                                                       RP18AZ
+
+General Data                                      RP18AZ24AJVCA  RP18AZ36AJVCA          RP18AZ48AJVCA  RP18AZ60AJVCA
+                                                          2.0            3.0                    4.0            5.0
+  MODEL NO.
+  Nominal Tonnage                                         3/8    3/8                    3/8                    3/8
+  Valve Connections                                       3/4                                                  7/8
+                                                          210    3/4                    7/8                    252
+                         Liquid Line O.D. - in.
+                        Suction Line O.D. - in.          28.3    212                    222                   32.5
+  Refrigerant (R410A) furnished oz.¹                      --                                                   --
+  Compressor Type                                        0.375                  Scroll                        0.375
+  Outdoor Coil                                             1                                                    1
+                    Net face area - Outer Coil            20     32.5                   32.5                   20
+                    Net face area - Inner Coil                    --                     --
+                                                          26     0.375                  0.375                  26
+                            Tube diameter - in.            3       1                      1                     3
+                               Number of rows             1/2     20                     20                    1/2
+                                   Fins per inch          282                                                  309
+                                                          278    24                     24                     301
+  Outdoor Fan
+                                  Diameter - in.                 3                      3
+
+                             Number of blades                    1/2                    1/2
+                                       Motor hp
+                                                                 306                    306
+  Shipping weight - lbs.
+  Operating weight - lbs.                                        298                    298
+
+Electrical Data
+
+Line Voltage Data (Volts-Phase-Hz)                208/230-1-60   208/230-1-60           208/230-1-60   208/230-1-60
+
+Maximum overcurrent protection (amps)²            30             50                     60             60
+
+Minimum circuit ampacity³                         22             32                     37             42
+
+Compressor
+
+                 Rated load amps                  15.4           24                     28.1           31.7
+
+            Locked rotor amps                     35             50                     50             50
+
+1Refrigerant charge sufficient for 15 ft. length of refrigerant lines. For longer line set requirements see the installation instructions for information about set length and additional
+ refrigerant charge required.
+2HACR type circuit breaker of fuse.
+3Refer to National Electrical Code manual to determine wire, fuse, and disconnect size requirements.
+
+                                                                                                                                                                                           5
+Accessories/Weighted Sound Power                        RP2024                       RP2036       RP2048              RP2060
+RP18AZ                                              RETST800SYS                  RETST800SYS  RETST800SYS         RETST800SYS
+
+Accessories                                             686020                       686020       686020              686020
+                                                      RXHT-A02                     RXHT-A02     RXHT-A02            RXHT-A02
+                          MODEL NO.
+    EcoNet® Smart Thermostat
+    Heat Pump Riser 6 in.
+    Supply/Return Sensor
+
+Weighted Sound Power Level (dBA)
+
+MODEL                                SOUND POWER           RP18AZ SOUND POWER LEVEL                               SOUND POWER
+                                     LEVEL [DB(A)]               FULL OCTAVE LINEAR SOUND POWER LEVEL DB -        LEVEL [DB(A)]
+                                      LOW SPEED/                                CENTER FREQUENCY - HZ       8000   WITH SOUND
+                                      HIGH SPEED
+                                                    125 250 500 1000 2000 4000 6300                                  BLANKET
+
+RP18AZ24AJVCA                        59             34.8 39.7 50.8 48.4 42.5 40.2 34.6 34.5                            Sound
+                                                                                                                     Blankets -
+                                     69             45.0 50.6 59.5 57.9 56.6 49.5 45.7 44.8                           Standard
+
+RP18AZ36AJVCA                        60             33.6 38.3 57.6 48.2 43.6 39.7 43.0 39.3
+
+                                     70             44.8 51.1 60.8 60.1 56.2 50.3 49.9 48.3
+
+RP18AZ48AJVCA                        59             34.0 38.9 52.3 48.0 43.5 39.8 42.2 37.3
+
+                                     73             48.5 54.4 65.4 63.1 58.0 55.0 53.3 51.6
+
+RP18AZ60AJVCA                        58             36.0 39.3 51.4 46.2 43.8 43.0 41.3 40.2
+
+                                     73             49.8 54.0 68.0 59.2 55.9 53.7 50.7 49.3
+
+NOTE: Tested in accordance with AHRI Standard 270-08 (not listed in AHRI)
+
+RP18AZ Sound Power
+
+               Model                 Sound Power    Full Octave
+
+                                                    125                    250   500          1000          2000  4000           6300
+
+       RP18AZ24AJVCA                     59         34.8                   39.7  50.8         48.4          42.5  40.2           34.6
+
+                                         69         45.0                   50.6  59.5         57.9          56.6  49.5           45.7
+
+       RP18AZ36AJVCA                     60         33.6                   38.3  57.6         48.2          43.6  39.7           43.0
+
+                                         70         44.8                   51.1  60.8         60.1          56.2  50.3           49.9
+
+       RP18AZ48AJVCA                     59         34.0                   38.9  52.3         48.0          43.5  39.8           42.2
+
+                                         73         48.5                   54.4  65.4         63.1          58.0  55.0           53.3
+
+       RP18AZ60AJVCA                     58         36.0                   39.3  51.4         46.2          43.8  43.0           41.3
+
+                                         73         49.8                   54.0  68.0         59.2          55.9  53.7           50.7
+
+NOTE: Tested in
+
+                                                     Refrigerant charge sufficient for 15 ft. length of refrigerant lines. For longer line set requirements see the installation instrucitons for inform
+                                                                                                                    length and additional refrigerant charge required.
+
+6
+                                                                                                     Unit Dimensions
+                                                                                                     RP18AZ
+
+Unit Dimensions
+
+                                   OPERATING                                          SHIPPING
+
+     MODEL       H (Height)        L (Length)          W (Width)  H (Height)          L (Length)     W (Width)
+        NO.
+               INCHES mm           INCHES mm   INCHES      mm     INCHES     mm  INCHES  mm          INCHES       mm
+RP18AZ24AJVCA
+RP18AZ36AJVCA  45.17  1147         36.13  918  36.13       918    48.18   1224   39.37   1000        39.64        1007
+RP18AZ48AJVCA
+RP18AZ60AJVCA  51.17  1300         36.13  918  36.13       918    53.56   1360   39.37   1000        39.64        1007
+
+               51.17  1300         36.13  918  36.13       918    53.56   1360   39.37   1000        39.64        1007
+
+               51.17  1300         36.13  918  36.13       918    53.56   1360   39.37   1000        39.64        1007
+
+MODEL                 OPERATING                                                          SHIPPING
+
+                      H (Height)               L (Length)         W (Width)              H (Height)                     L (Length)
+
+                      INCHES       mm          INCHES      mm     INCHES         mm      INCHES             mm                    INCHES
+
+RP18AZ24AJVCA         45.17        1147        36.13       918    36.13          918     48.18              1224                  39.37
+
+RP18AZ36AJVCA         51.17        1300        36.13       918    36.13          918     53.56              1360                  39.37
+
+RP18AZ48AJVCA         51.17        1300        36.13       918    36.13          918     53.56              1360                  39.37
+
+RP18AZ60AJVCA         51.17        1300        36.13       918    36.13          918     53.56              1360                  39.37
+
+[ ] Designates Metric Conversions                                                                 ST-A1226-02-00
+                                                                                                                               7
+8                                                                                                                                                                                                                                     Clearances
+                                                                                                                                                                                                                                  RP18AZ
+   CLEARANCES
+                                                                                                                                                                                             WALL
+                   WALL
+                                                                                                                                                                                                            24
+                            6                                                                                                                                                                            (609.6)
+                         (152.4)                                                                                                                                                                         Service
+
+     24                    12                                                                                                                                                         12                                   WALL
+   (609.6)               (304.8)                                                                                                                                                    (304.8)
+   Service
+
+                                                                                                                                                                                                                     6
+                                                                                                                                                                                                                  (152.4)
+
+               6
+            (152.4)
+
+                                                                                                                                                                                               12
+                                                                                                                                                                                             (304.8)
+
+              24                         WALL                                                                                                                                                  24
+            (609.6)                                                                                                                                                                          (609.6)
+            Service                         24                                                                                                                                               Service
+                                         (609.6)
+                                         Service
+
+     18                           24                       24
+   (457.2)                     (609.6)                  (609.6)
+
+                         24 recommended           24 recommended
+                         6 minimum                6 minimum
+
+   NOTE: NUMBERS IN () = mm
+
+   IMPORTANT: When installing multiple units in an alcove, roof well or partially enclosed area, ensure there is adequate ventillation to prevent re-circulation of discharge air.
+
+                                                                                                                                                                                                                  ST-A1225-01-00
+                                                                                                                                                   Refrigerant Line Size Information
+                                                                                                                                                   RP18AZ
+
+Refrigerant Line Size Information
+
+                                        18 SEER2 VARIABLE SPEED HEAT PUMPS
+
+         ALLOWABLE           ALLOWABLE           OUTDOOR UNIT ABOVE OR BELOW INDOOR UNIT
+                                                             EQUIVALENT LENGTH (FEET)
+UNIT SIZE LILNIQEUSIIDZE LIVNAEPSOIRZE < 25
+                                                 26-50    51-75             76-100                                                                 101-125  126-150
+
+                                                 MAXIMUM VERTICAL SEPARATION/CAPACITY MULTIPLIER                                                               NR
+                                                                                                                                                            50/0.95
+         1/4"                5/8"       25/1.00  50/0.99  33/0.98           60/0.97                                                                NR       50/0.95
+
+2.0 TON  5/16"               5/8"       25/1.00  50/0.99  50/0.98           50/0.97                                                                50/0.96     NR
+ *SEE    3/8"                5/8"       25/1.00  50/0.99  50/0.98           50/0.97                                                                50/0.96  50/0.98
+NOTE 3   1/4"                3/4"*      25/1.00  50/1.00  33/0.99           60/0.99                                                                         50/0.98
+         5/16"               3/4"*      25/1.00  50/1.00  50/0.99           50/0.99                                                                  NR
+                                                                                                                                                   50/0.99     NR
+                                                                                                                                                               NR
+         3/8"                3/4"*      25/1.00  50/1.00  50/0.99           50/0.99                                                                50/0.99  20/0.96
+                                                                                                                                                            50/0.96
+         5/16"               5/8"       25/0.99  50/0.97  50/0.95           50/0.93                                                                36/0.91  50/0.96
+                                                                                                                                                            50/0.92
+         3/8"                5/8"       25/0.99  50/0.97  50/0.95           50/0.93                                                                50/0.91  50/0.92
+                                                                                                                                                            50/0.97
+3 TON    5/16"               3/4"       25/1.00  50/0.99  50/0.99           50/0.98                                                                36/0.97  50/0.97
+                                                                                                                                                               NR
+         3/8"                3/4"       25/1.00  50/0.99  50/0.99           50/0.98                                                                50/0.97     NR
+                                                                                                                                                            38/0.95
+         1/2"                3/4"       25/1.00  50/0.99  50/0.99           50/0.98                                                                50/0.97  50/0.95
+                                                                                                                                                            38/0.99
+         3/8"                3/4"       25/0.99  50/0.98  50/0.96           50/0.95                                                                50/0.93  50/0.99
+
+                       1/2"  3/4"       25/0.99  50/0.98  50/0.96           50/0.95                                                                50/0.93
+4 TON
+                             7/8"       25/1.00  50/0.99  50/0.99           50/0.98                                                                50/0.98
+                       3/8"
+
+         1/2"                7/8"       25/1.00  50/0.99  50/0.99           50/0.98                                                                50/0.98
+
+         3/8"                3/4"       25/0.98  50/0.97  50/0.95           50/0.93                                                                46/0.91
+
+         1/2"                3/4"       25/0.98  50/0.97  50/0.95           50/0.93                                                                50/0.91
+
+                       3/8"  7/8"       25/0.99  50/0.99  50/0.98           50/0.97                                                                50/0.96
+5 TON
+                             7/8"       25/0.99  50/0.99  50/0.98           50/0.97                                                                50/0.96
+                       1/2"
+
+         3/8"                1-1/8"**   25/1.00  50/1.00  50/1.00           50/0.99                                                                50/0.99
+
+         1/2"                1-1/8"**   25/1.00  50/1.00  50/1.00           50/0.99                                                                50/0.99
+
+NOTES:
+1) **Do not exceed 150 ft. linear line length.
+2) **Do not exceed 50 ft. vertical separation between indoor and outdoor units.
+3) **3/4" vapor line should only be used for 2 ton systems if outdoor unit is below or at same level as indoor unit to assure proper oil return.
+4)**1-1/8" vapor line should only be used for 5 ton systems if outdoor unit is below or at same level as indoor unit to assure proper oil return.
+5) **Always use the smallest liquid line allowable to minimize refrigerant charge.
+6) **Applications shaded in light gray indicate capacity multipliers between 0.90 and 0.96 which are not recommended, but are allowed.
+7) **Applications shaded in dark gray are not recommended due to excessive liquid or suction pressure drop.
+
+                                                                                                                                                                     9
+Refrigerant Line Size Information
+RP18AZ
+
+Refrigerant Line Size Information (Con't.)
+
+                                                    18 SEER2 VARIABLE SPEED HEAT PUMPS
+
+               ALLOWABLE           ALLOWABLE                      OUTDOOR UNIT ABOVE OR BELOW INDOOR UNIT
+                                                                            EQUIVALENT LENGTH (METERS)
+    UNIT SIZE  LIQUID              VAPOR
+                                                    < 8     9-15     16-23              24-30    31-38                                                         39-46
+               LINE SIZE           LINE SIZE
+                                                            MAXIMUM VERTICAL SEPARATION/CAPACITY MULTIPLIER                                                     NR
+                                                                                                                                                              15/0.95
+               6.35 [1/4]          15.88 [5/8]      8/1.00  15/0.99  10/0.98            20/0.97            NR                                                 15/0.95
+
+     7.0 kW    7.94 [5/16]         15.88 [5/8]      8/1.00  15/0.99  15/0.98            15/0.97  15/0.96                                                        NR
+    [2.0 TON]  9.53 [3/8]          15.88 [5/8]      8/1.00  15/0.99  15/0.98            15/0.97  15/0.96                                                      15/0.98
+               6.35 [1/4]          19.05 [3/4]      8/1.00  15/0.99  10/0.99            20/0.99                                                               15/0.98
+      *SEE     7.94 [5/16]         19.05 [3/4]      8/1.00  15/0.99  15/0.99            15/0.99    NR
+     NOTE 3                                                                                      15/0.99                                                        NR
+                                                                                                                                                                NR
+               9.53 [3/8]          19.05 [3/4]      8/1.00  15/0.99  15/0.99            15/0.99  15/0.99                                                      6/0.96
+                                                                                                                                                              15/0.96
+               7.94 [5/16]         15.88 [5/8]      8/0.99  15/0.97  15/0.95            15/0.93  11/0.91                                                      15/0.96
+                                                                                                                                                              15/0.92
+    10.6 kW    9.53 [3/8]          15.88 [5/8]      8/0.99  15/0.97  15/0.95            15/0.93  15/0.91                                                      15/0.92
+    [3 TON]    7.94 [5/16]         19.05 [3/4]      8/1.00  15/0.99  15/0.99            15/0.98  11/0.97                                                      15/0.97
+               9.53 [3/8]          19.05 [3/4]      8/1.00  15/0.99  15/0.99            15/0.98  15/0.97                                                      15/0.97
+                                                                                                                                                                NR
+               12.70 [1/2]         19.05 [3/4]      8/1.00  15/0.99  15/0.99            15/0.98  15/0.97                                                        NR
+                                                                                                                                                              12/0.95
+               9.53 [3/8]          19.05 [3/4]      8/0.99  15/0.98  15/0.96            15/0.95  15/0.93                                                      15/0.95
+                                                                                                                                                              12/0.99
+    14.1 kW    12.70 [1/2]         19.05 [3/4]      8/0.99  15/0.98  15/0.96            15/0.95  15/0.93                                                      15/0.99
+    [4 TON]     9.53 [3/8]         22.23 [7/8]      8/1.00  15/0.99  15/0.99            15/0.98  15/0.98
+
+               12.70 [1/2]         22.23 [7/8]      8/1.00  15/0.99  15/0.99            15/0.98  15/0.98
+
+               9.53 [3/8]          19.05 [3/4]      8/0.98  15/0.97  15/0.95            15/0.93  14/0.91
+
+               12.70 [1/2]         19.05 [3/4]      8/0.98  15/0.97  15/0.95            15/0.93  15/0.91
+
+    17.6 kW     9.53 [3/8]         22.23 [7/8]      8/0.99  15/0.99  15/0.98            15/0.97  15/0.96
+    [5 TON]    12.70 [1/2]         22.23 [7/8]      8/0.99  15/0.99  15/0.98            15/0.97  15/0.96
+
+               9.53 [3/8]          28.58 [1-1/8]**  8/1.00  15/0.99  15/0.99            15/0.99  15/0.99
+
+               12.70 [1/2]         28.58 [1-1/8]**  8/1.00  15/0.99  15/0.99            15/0.99  15/0.99
+
+NOTES:
+1)  Do not exceed 46 meters linear line length.
+2)  Do not exceed 15 meters vertical separation between indoor and outdoor units.
+3)  *19.05mm [3/4"] vapor line should only be used for 2 ton systems if outdoor unit is below or at same level as indoor unit to assure proper oil return.
+4) **28.58mm [1-1/8"] vapor line should only be used for 5 ton systems if outdoor unit is below or at same level as indoor unit to assure proper oil return.
+5)  Always use the smallest liquid line allowable to minimize refrigerant charge.
+6)  Applications shaded in light gray indicate capacity multipliers between 0.90 and 0.96 which are not recommended, but are allowed.
+7)  Applications shaded in dark gray are not recommended due to excessive liquid or suction pressure drop.
+
+10
+            Capacity Ranges
+            RP18AZ
+
+(-)P18AZ24
+
+(-)P18AZ24
+
+            11
+Capacity Ranges
+RP18AZ
+
+                 (-)P18AZ36
+
+                             (-)P18AZ36
+
+12
+            Capacity Ranges
+            RP18AZ
+
+(-)P18AZ48
+
+(-)P18AZ48
+
+                                                                                                                                                           13
+Capacity Ranges
+RP18AZ
+
+                 (-)P18AZ60
+
+                 (-)P18AZ60
+
+14
+                                                                                                   Performance Data
+                                                                                                   RP18AZ
+
+Performance Data @ AHRI Standard Conditions - Cooling
+
+DESIGNATED TESTED COMBINATION (DTC)
+
+OUTDOOR UNIT AIR HANDLER    TOTAL       NET      NET        SEER2 EER2 CIFNMDO[LO/Rs]  47 DEGREE      47 17 DEGREE 17 REGION
+                          CAPACITY   SENSIBLE  LATENT                                   HEATING                 HEATING DEGREE IV
+                                                                                        CAPACITY
+                          BTU/H [kW] BTU/H [kW] BTU/H [kW]                             BTU/H [kW]  DECGORPEE CAPACITY COP HSPF2
+                                                                                                               BTU/H [kW]
+
+RP18AZ24AJVC RHMVZ2421HEACA 22800 [6.7] 17500 [5.1] 5300 [1.6] 18.0 12.5 785 [370.5] 22800 [6.7] 3.00 23000 [6.7] 2.00 8.5
+
+RP18AZ36AJVC RHMVZ6021SEACA 34200 [10.0] 26200 [7.7] 8000 [2.3] 18.0 12.5 1225 [578.1] 32000 [9.4] 3.00 37400 [11.0] 2.00 8.5
+
+RP18AZ48AJVC RHMVZ6021SEACA 45800 [13.4] 34500 [10.1] 10500 [3.1] 18.0 12.0 1590 [750.4] 40000 [11.7] 2.50 41000 [12.0] 1.50 8.5
+
+RP18AZ60AJVC RHMVZ6021SEACA 53000 [15.5] 40600 [11.9] 12400 [3.6] 18.0 10.5 1685 [795.2] 48500 [14.2] 2.50 47000 [13.8] 1.50 8.5
+
+NOTE: This data includes DTC (Designated Test Combination) ratings and is for reference purposes only. A full listing of official ratings and system match-ups, along with
+       downloadable certificates, can be accessed from the AHRI website: www.ahridirectory.org.
+
+[ ] Designates Metric Conversions
+
+                                                                                                                                                                            15
+Smart Home Systems
+RP18AZ
+
+Integrated Controls
+
+    EcoNet® is smart, technology developed exclusively by Rheem that allows Heating, Cooling,
+      and Water Heating products to communicate with each other on one integrated network.
+
+THE ECONET® SMART THERMOSTAT
+
+BUILT-IN WIFI                                                                                  RETST800SYS
+4.3" LCD TOUCH SCREEN
+LOCAL WEATHER - Current conditions plus 6-day forecast
+5 OPERATING MODES - Heat, Cool, Auto, Emergency Heat and Fan Only
+7-DAY PROGRAMMABLE SCHEDULE - Offers comfort without thought
+ONE-TOUCH AWAY - Quickly switch to your energy-saving away preferences
+VACATION SCHEDULING - Allows you to save while you're away and come home to comfort
+STANDBY SCREEN - Displays indoor temperature and current weather
+
+OPERATIONAL FEATURES
+
+AUTOMATIC CHANGEOVER - Transitions between heating and cooling automatically to keep the house comfortable
+INTEGRATED WATER CONTROL - Enables easy water heater management
+SMOOTH ARRIVAL - Prompts the system to start ahead of schedule to ensure the home is at the desired temperature at the scheduled time
+HUMIDITY CONTROL - Supports humidifier accessories or over-cool based dehumidification
+DETAILED OPERATING STATUS - View pertinent equipment status information and run times
+CONTINUOUS FAN - Offers 5 speeds (Low, Medium Low, Medium, Medium High, High)
+SHORT-CYCLE PROTECTION - Avoids damage to equipment from short run cycles
+
+MONITORING & REMOTE CONTROL FEATURES
+
+ACTIVE MONITORING - Alerts to problems that need immediate attention
+REMOTE CONTROL - Allows adjusting of comfort and settings from anywhere using a mobile device
+SERVICE ALERTS - Sends routine maintenance reminders
+AIR FILTER MONITORING - Detects when it's time to replace the air filter
+ALARM HISTORY - Displays time-stamped alarm codes with clear descriptions
+
+16
+Notes
+RP18AZ
+
+      17
+Notes
+RP18AZ
+
+18
+Notes
+RP18AZ
+
+      19
+GENERAL TERMS OF LIMITED WARRANTY*                                           Conditional Unit Replacement
+                                                                             (Registration Required)............................. Ten (10) Years
+Rheem will furnish a replacement for any part of this product                Parts....................................................... Ten (10) Years
+which fails in normal use and service within the applicable
+period stated, in accordance with the terms of the limited
+warranty.
+
+ *For complete details of the Limited and Conditional Warranties, including
+applicable terms and conditions, contact your local contractor or the
+Manufacturer for a copy of the product warranty certificate.
+
+Before proceeding with installation, refer to installation instructions packaged with each model, as well as complying with all Federal,
+                                                   State, Provincial, and Local codes, regulations, and practices.
+
+                  © 2023 Rheem Manufacturing Company. Rheem trademarks owned by Rheem Manufacturing Company.
+In keeping with its policy of continuous progress and product improvement, Rheem reserves the right to make changes without notice.
+
+Rheem Heating, Cooling & Water Heating · 5600 Old Greenwood Road             Rheem Canada Ltd./Ltée · 125 Edgeware Road, Unit 1
+                Fort Smith, Arkansas 72908 · www.rheem.com                           Brampton, Ontario · L6Y 0P5 · rheem.ca
+
+                                                                             PRINTED IN U.S.A. 12/23 QG FORM NO. P11-823 REV. 3
+

--- a/data/heat-pumps/rheem/endeavor-line-select-wp15az/raw.txt
+++ b/data/heat-pumps/rheem/endeavor-line-select-wp15az/raw.txt
@@ -1,0 +1,543 @@
+                                                                                                                                                                                                                  Heat Pumps
+                                                                                                                                                                                                                  WP15AZ
+
+           EndeavorTM Line Select® Series
+                       iC Heat Pumps
+
+              WP15AZ
+
+                 Cooling Efficiencies up to: 16 SEER2/11.7 EER2
+                 Heating Efficiencies up to: 8.1 HSPF2
+                 Nominal Sizes: 11/2 to 5 Ton [5.28 to 17.6 kW]
+                 Cooling Capacities: 17.1 to 55.5 kBTU [5.0 to 16.3 kW]
+
+                                                                                *
+
+*Proper sizing and installation of equipment is critical to achieve optimal performance. Split system air conditioners and heat pumps
+must be matched with appropriate coil components to meet Energy Star. Ask your Contractor for details or visit www.energystar.gov.
+
+                                                                                                                                                                                                                                                                                       FORM NO. P33-837 REV. 1
+Table of Contents
+WP15AZ
+
+                                          Table of Contents
+
+                   Features & Benefits...................................................................3
+                   Model Number Identification.....................................................4
+                   General Data/Electrical Data.....................................................5
+                   Accessories...............................................................................6
+                   Weighted Sound Power........................................................... 6
+                   Unit Dimensions........................................................................7
+                   Clearances................................................................................8
+                   Refrigerant Line Size Information........................................ 9-10
+                   Performance Data...................................................................11
+                   Limited Warranty.....................................................................12
+
+2
+Features and Benefits                                                                                                                             Features and Benefits
+                                                                                                                                                  WP15AZ
+· Fully Louvered Steel Cabinet: Features durable construction
+   to add protection from yard hazards, weather corrosion        · Inverted Reversing Valve: Allows for faster heat transfer with
+                                                                    gravity assist shifting and reduced joint stress for increased
+· Two-Stage Scroll Compressor: Features two speeds (high            reliability
+   and low) of cooling and heating, providing more precise
+   temperature control, lower humidity and greater efficiency    · Easily Accessible Control Box: Ease of installation and
+   when compared to single stage compressors                        serviceability
+
+· 7 mm Condenser Copper Coil1: Requires less refrigerant
+   allowing for a smaller and lighter footprint while enhancing
+   reliability
+
+1Does not apply to the 5 Ton Model
+                                                                                                                                                                                                          3
+Model Number Identification
+WP15AZ
+
+ Heat Pumps
+
+   W              P              15               A                 Z           18                      A                   J             2            N                      A
+
+       Brand         Product          SEER2           Region       Refrigerant  Capacity                Major Series    Voltage              Type               Controls      Minor Series
+W - Rheem Select     Category    15 - 15.2 SEER2  A - All Regions  Z - R-410A                                                             2 - 2-Stage  N - Non-Communicating  A - 1st Design
+                                                                                18 - 18,000 [5.28 kW]   A - 1st Design  J - 208/230/1/60
+                  P - Heat Pump                                                 24 - 24,000 [7.03 kW]
+                                                                                30 - 30,000 [8.79 kW]
+                                                                                36 - 36,000 [10.55 kW]
+                                                                                42 - 42,000 [12.31 kW]
+                                                                                48 - 48,000 [14.07 kW]
+                                                                                60 - 60,000 [17.58 kW]
+
+[ ] Designates Metric Conversions
+
+      AVAILABLE MODELS                                                                                                           STANDARD EQUIPMENT
+        WP15AZ18AJ2N
+        WP15AZ24AJ2N                                                                                    R-410A Refrigerant
+        WP15AZ30AJ2N
+        WP15AZ36AJ2N                                                                                    Scroll Compressor
+        WP15AZ42AJ2N
+        WP15AZ48AJ2N                                                                                    Field Installed Filter Drier
+        WP15AZ60AJ2N
+                                                  BRAND                         PRODUCT CATE-           Front Seating Service Valves         CAPACITY                         MAJOR SE- VOLTAGE
+                                                  W - Rheem Select              P - Heat Pump           SEER2 REGION REFRIGER-               18 - 18,000 [5.28 kW]            A - 1ST DE- J - 208/230 / 1
+                                                                                                        Internal Pressure Relief Valve       24 - 24,000 [7.03 kW]
+                                                                                                        14 - 14.3 A - ALL RE- Z - R-410A     30 - 30,000 [8.79 kW]
+                                                                                                        Internal Thermal Overload            36 - 36,000 [10.55 kW]
+                                                                                                        Long Line capability                 42 - 42,000 [12.31 kW]
+                                                                                                        Low Ambient capability with Kit
+                                                                                                        3-4-5 Expanded Valve Space
+                                                                                                        Optimized Venturi Airflow
+
+                                                                                                        Single row condenser coil            48 - 48,000 [14.07 kW]
+
+                                                                                                        Rust resistant screws                60 - 60,000 [17.58 kW]
+                                                                                                        QR code
+
+                                                                                                        External gauge ports
+
+                     WP15AZ18AJ1NA
+
+                     WP15AZ18AJ2NA                                                                      WP15AZ18AJ1NA
+
+                     WP15AZ24AJ2NA                                                                      WP15AZ18AJ2NA                                                                         R-
+
+                     WP15AZ30AJ2NA                                                                      WP15AZ24AJ2NA                                                                         Sc
+
+                     WP15AZ36AJ2NA                                                                      WP15AZ30AJ2NA                                                                         Fie
+
+                     WP15AZ42AJ2NA                                                                      WP15AZ36AJ2NA                                                                         Fro
+
+                     WP15AZ48AJ2NA                                                                      WP15AZ42AJ2NA                                                                         Int
+
+                     WP15AZ60AJ2NA                                                                      WP15AZ48AJ2NA                                                                         Int
+
+                                                                                                        WP15AZ60AJ2NA                                                                         Lo
+
+                                                                                                                                                                                              Lo
+
+                                                                                                                                                                                              3-
+
+                                                                                                                                                                                              Co
+
+                                                                                                                                                                                              2 S
+
+                                                                                                                                                                                              15
+
+                                                                                                                                                                                              Qu
+
+                                                                                                                                                                                              No
+
+4                                                                                                                                                                                             Op
+
+                                                                                                                                                                                              Sin
+                                                                                                           General Data/Electrical Data
+                                                                                                           WP15AZ
+
+General Data                                       (-)P15AZ  (-)P15AZ  (-)P15AZ  (-)P15AZ        (-)P15AZ  (-)P15AZ  (-)P15AZ
+                                                   18AJ2NA   24AJ2NA   30AJ2NA   36AJ2NA         42AJ2NA   48AJ2NA   60AJ2NA
+  MODEL NO.
+                                                     0.375     0.375   0.375          0.375      0.375       0.375     0.375
+  Nominal Tonnage                                    0.75      0.75    0.75           0.75       0.875       0.875     0.875
+  Valve Connections                                   118       118     120            127        143         146       220
+                                                                                 2-stage Scroll
+                          Liquid Line O.D. - in.     10.9      10.9                                          21.5      32.5
+                        Suction Line O.D. - in.      10.5      10.5    19.5      21.5            21.5
+  Refrigerant (R410A) furnished oz.¹                 0.276     0.276                                         0.276     0.375
+  Compressor Type                                                      0.276     0.276           0.276         1         1
+  Outdoor Coil                                         2         2       1         1               1           22        20
+                    Net face area - Outer Coil         22        22     22        22              22
+                     Net face area - Inner Coil                                                                24        26
+                                                       20        20    24        24              24            3         3
+                            Tube diameter - in.        2         2                                            1/5       1/5
+                               Number of rows         1/6       1/6    3         3               3           4206      5106
+                                   Fins per inch     2582      2582                                           850       850
+                                                     1075      1075    1/5       1/5             1/5          246       294
+  Outdoor Fan                                         145       145
+                                  Diameter - in.                       4077      4206            4206
+
+                              Number of blades                         850       850             850
+                                        Motor hp
+                                             CFM                       222       246             246
+                                             RPM
+                                            watts                            COMING SOON
+
+  Shipping weight - lbs.
+  Operating weight - lbs.
+
+Electrical Data
+
+Line Voltage Data (Volts-Phase-Hz)                 208/230-1-60 208/230-1-60 208/230-1-60 208/230-1-60 208/230-1-60 208/230-1-60 208/230-1-60
+
+Maximum overcurrent protection (amps)²             15        25        30        30              45        45        50
+
+Minimum circuit ampacity³                          11        15        18        20              26        28        31
+
+Compressor
+
+                           Rated load amps         8         11        14        15              20        21        24
+
+                     Locked rotor amps             56        61        87        102             151       0         151
+
+Condenser Fan Motor
+
+                           Full load amps          0.75      0.75      1.0       1.0             1.0       1.0       1.0
+
+                     Locked rotor amps             1.5       1.5       2.56      2.56            2.56      2.56      2.56
+
+¹Refrigerant charge sufficient for 15 ft. length of refrigerant lines. For longer line set requirements see the installation instructions for information about set length and additional
+refrigerant charge required.
+²HACR type circuit breaker of fuse.
+³Refer to National Electrical Code manual to determine wire, fuse and disconnect size requirements.
+
+                                                                                                                                                                                           5
+Accessories/Weighted Sound Power
+WP15AZ
+
+Accessories
+
+MODEL NO.                                WP15AZ18**2           WP15AZ24                             WP15AZ30          WP15AZ36            WP15AZ42         WP15AZ48           WP15AZ60
+                                                                                                  44-17402-44       44-17402-44         44-17402-45       44-17402-45     Factory Standard
+Compressor crankcase heater*                 44-17402-44   44-17402-44                              RXAD-A08          RXAD-A08            RXAD-A08          RXAD-A08
+                                                                                                  68-23427-26       68-23427-26         68-23427-25       68-23427-25         RXAD-A08
+Low ambient control                          RXAD-A08          RXAD-A08                                                                                                     68-23427-25
+                                                                                                      SK-A1             SK-A1               SK-A1             SK-A1
+Compressor sound cover                       68-23427-26   68-23427-26                          Factory Standard  Factory Standard    Factory Standard  Factory Standard        SK-A1
+                                                                                                Factory Standard  Factory Standard    Factory Standard  Factory Standard  Factory Standard
+Compressor hard start kit                    SK-A1               SK-A1                           200RD2T3TVLC      200RD2T3TVLC        200RD2T3TVLC      200RD3T3TVLC     Factory Standard
+                                                                                                                                                                           200RD3T3TVLC
+Low pressure control                     Factory Standard Factory Standard                         61-AMG24V         61-AMG24V           61-AMG24V         61-AMG24V
+                                                                                                 200RD2T3TVLC      200RD2T3TVLC        200RD2T3TVLC      200RD3T3TVLC        61-AMG24V
+High pressure control                    Factory Standard Factory Standard                      61-AMG120/240V    61-AMG120/240V      61-AMG120/240V    61-AMG120/240V     200RD3T3TVLC
+                                                                                                  91-101123-21      91-101123-21        91-101123-21      91-101123-21    61-AMG120/240V
+Liquid Line Solenoid     Solenoid Valve   200RD2T3TVLC      200RD2T3TVLC                                                                                                    91-101123-21
+(24 VAC, 50/60 Hz)       Solenoid Coil      61-AMG24V         61-AMG24V
+
+Liquid Line Solenoid     Solenoid Valve   200RD2T3TVLC      200RD2T3TVLC
+(120/240 VAC,            Solenoid Coil   61-AMG120/240V    61-AMG120/240V
+50/60 Hz)
+                                           91-101123-21      91-101123-21
+Classic Top Cap w/Label
+
+*Bi-flow kits are required when installing a liquid line solenoid on a heat pump.
+
+Weighted SoMoudenl Ndo. Power Level (dBA) WP15AZ18**1                                                             WP15AZ18**2               WP15AZ24                      WP15AZ30
+
+   UCNoImTpSreIZssEo-r crankcase heateSr*TANDARD                 44-17402-44TYPICAL OCTAVE4B4A-1N7D40S2P-4E4CTRUM (dBA with4o4u-t17to4n0e2-4a4djustment)                  44-17402-44
+VOLTLAoGwEa,mSbEieRnItEcSontrol RATING (DBA)
+                                                           125 RXAD-A08250                            500RXAD-A08 1000                      R2X0A0D0-A08     4000          RXAD8-0A0080
+                                                                                                                                                                          68-2345207.-526
+WPC1o5mApZre1s8sAor sound cover          73                58.0 68-23427-2568.8                       626.08-23427-26 62.3                  685-293.2427-26  56.6
+
+WPC1o5mApZre2s4sAor hard start kit       73                56.6 SK-A1 59.6                            62.2 SK-A1 62.1                       5S8K.8-A1        55.4         SK-5A01.8
+
+WPL1ow5ApZre3s0sAure control             72                48.9 Factory Stand5ar5d.3                  6F3a.c6tory Standard 61.0             Fact5or9y.1Standard 56.5 Factory S4ta8n.7dard   Fa
+
+WPH1ig5hApZr3e6ssAure control            74                51.2 Factory Stand5ar6d.4                  6F3a.c1tory Standard 63.8             Fact6or0y.8Standard 57.4 Factory S5ta6n.5dard   Fa
+
+WPL1iq5uAidZL4i2neASolenoid              74                56.8                           58.7        65.9                      66.2        62.9             59.4         54.2
+
+WP(2145AVAZC4,85A0/60 Hz)                S7o4lenoid Valve  57.3 200RD2T3TV5L6C.6                      6240.10RD2T3TVLC 64.0                 2006R1D.21T3TVLC 58.0 200RD2T536T.5VLC          2
+
+WP15AZ60A                                S7o4lenoid Coil   43.9 61-AMG24V55.2                         63.641-AMG24V 65.8                    616-1A.M7G24V    57.9         61-AM5G22.49V
+
+NOTE: TesteLdiqiunidaLcicnoerdSaonlecneoiwdith AHRI Standard 270-08 (not listed in AHRI)
+
+(120/240 VAC, 50/60 Hz)                  Solenoid Valve          200RD2T3TVLC                                     200RD2T3TVLC              200RD2T3TVLC                  200RD2T3TVLC      2
+
+                                         Solenoid Coil           61-AMG120/240V                       61-AMG120/240V                        61-AMG120/240V                61-AMG120/240V    61
+
+Classic Top Cap w/Label                                          91-101123-21                                     91-101123-21              91-101123-21                  91-101123-21
+
+                       Unit Size -       Standard TYPICAL
+Voltage, Series Rating (dBA) OCTAVE
+
+                                                           125                            250   500               1000                2000  4000             8000
+
+                      WP15AZ18A              73            58                             58.8  62                62.3                59.2  56.6             50.5
+
+                      WP15AZ24A              73            56.6                           59.6  62.2              62.1                58.8  55.4             50.8
+
+                      WP15AZ30A              72            48.9                           55.3  63.6              61                  59.1  56.5             48.7
+
+                      WP15AZ36A              74            51.2                           56.4  63.1              63.8                60.8  57.4             56.5
+
+                      WP15AZ42A              74            56.8                           58.7  65.9              66.2                62.9  59.4             54.2
+
+                      WP15AZ48A              74            57.3                           56.6  64.1              64                  61.1  58               56.5
+
+                      WP15AZ60A              74            43.9                           55.2  63.4              65.8                61.7  57.9             52.9
+
+                                                     Refrigerant charge sufficient for 15 ft. length of refrigerant lines. For longer line set requirements see the installation instrucitons for inform
+                                                                                                                    length and additional refrigerant charge required.
+
+6
+                                                                                                                                  Unit Dimensions
+                                                                                                                                  WP15AZ
+
+Unit Dimensions
+
+                                       OPERATING                                                             SHIPPING
+
+      MODEL      H (Height)            L (Length)           W (Width)                    H (Height)          L (Length)           W (Width)
+        NO.
+                 INCHES    mm          INCHES   mm          INCHES   mm       INCHES       mm        INCHES     mm       INCHES    mm
+(-)P15AZ18AJ2NA  25.170   639.32       29.543  750.39       29.543  750.39    27.063      687.39     32.625    828.68    32.625   828.68
+(-)P15AZ24AJ2NA  25.170   639.32       29.543  750.39       29.543  750.39    27.063      687.39     32.625    828.68    32.625   828.68
+(-)P15AZ30AJ2NA  35.170   893.32       33.655  854.84       33.655  854.84    37.063      941.39     36.625    930.28    36.625   930.28
+(-)P15AZ36AJ2NA  39.170   994.92       33.655  854.84       33.655  854.84    41.063     1042.99     36.625    930.28    36.625   930.28
+(-)P15AZ42AJ2NA  39.170   994.92       33.655  854.84       33.655  854.84    41.063     1042.99     36.625    930.28    36.625   930.28
+(-)P15AZ48AJ2NA  39.170   994.92       33.655  854.84       33.655  854.84    41.063     1042.99     36.625    930.28    36.625   930.28
+(-)P15AZ60AJ2NA  51.170  1299.72       35.543  902.79       35.543  902.79    53.063     1347.79     38.625    981.08    38.625   981.08
+
+                 (-)P15AZ18AJ2NA       25.170      639.32   29.543       750.39          29.543      750.39  27.063      687.39   32.625                             828.68
+                 (-)P15AZ24AJ2NA       25.170      639.32   29.543       750.39          29.543      750.39  27.063      687.39   32.625                             828.68
+                 (-)P15AZ30AJ2NA       35.170      893.32   33.655       854.84          33.655      854.84  37.063      941.39   36.625                             930.28
+                 (-)P15AZ36AJ2NA       39.170      994.92   33.655                       33.655      854.84  41.063      1042.99  36.625                             930.28
+                 (-)P15AZ42AJ2NA       39.170      994.92   33.655     H 854.84          33.655      854.84  41.063      1042.99  36.625                             930.28
+                                       39.170      994.92   33.655                       33.655      854.84  41.063      1042.99  36.625                             930.28
+                 (-)P15AZ48AJ2NA W     51.170      1299.72  35.543       854.84          35.543      902.79  53.063      1347.79  38.625                             981.08
+                                                                         854.84
+                 (-)P15AZ60AJ2NA                                         902.79
+
+L
+
+                                                                       LOW VOLTAGE                                       HIGH VOLTAGE
+                                                                            7/8 [22 mm]                                  13/32 [27 mm]
+                                                                                                                         HOLE DIAMETER
+                                                                    HOLE DIAMETER
+
+                                                                    SERVICE                                                       SERVICE
+                                                                     FITTING                                                      FITTING
+
+                                                                                LIQUID LINE                              VAPOR LINE
+                                                                              CONNECTION                                 CONNECTION
+
+                         SEE DETAIL A                                                                DETAIL A                                       Illustration
+[ ] Designates Metric Conversions                                                                                                                ST-A1331-01
+                                                                                                                                             Rev. 10-20-2022
+
+                                                                                                                                                                  7
+8                                                                                                                                                                                                                                     Clearances
+                                                                                                                                                                                                                                  WP15AZ
+   CLEARANCES
+                                                                                                                                                                                             WALL
+                   WALL
+                                                                                                                                                                                                            24
+                            6                                                                                                                                                                            (609.6)
+                         (152.4)                                                                                                                                                                         Service
+
+     24                    12                                                                                                                                                         12                                   WALL
+   (609.6)               (304.8)                                                                                                                                                    (304.8)
+   Service
+
+                                                                                                                                                                                                                     6
+                                                                                                                                                                                                                  (152.4)
+
+               6
+            (152.4)
+
+                                                                                                                                                                                               12
+                                                                                                                                                                                             (304.8)
+
+              24                         WALL                                                                                                                                                  24
+            (609.6)                                                                                                                                                                          (609.6)
+            Service                         24                                                                                                                                               Service
+                                         (609.6)
+                                         Service
+
+     18                           24                       24
+   (457.2)                     (609.6)                  (609.6)
+
+                         24 recommended           24 recommended
+                         6 minimum                6 minimum
+
+   NOTE: NUMBERS IN () = mm
+
+   IMPORTANT: When installing multiple units in an alcove, roof well or partially enclosed area, ensure there is adequate ventillation to prevent re-circulation of discharge air.
+
+                                                                                                                                                                                                                  ST-A1225-01-00
+                                                                                                                                              Refrigerant Line Size Information
+                                                                                                                                              WP15AZ
+
+Refrigerant Line Size Information
+
+                                       SINGLE- AND TWO-STAGE HEAT PUMPS
+
+                                                  OUTDOOR UNIT ABOVE OR BELOW INDOOR UNIT
+
+UNIT     MAX.  SUCTION                            EQUIVALENT LENGTH (FEET)
+
+SIZE LILNIQEUSIIDZE LINE SIZE  0-15    16-25      26-50                                                                51-80      81-100      101-125      126-150
+
+                                                  MAXIMUM VERTICAL SEPARATION/CAPACITY MULTIPLIER                                                         115 / 0.95
+                                                                                                                                                          115 / 0.98
+               1/2"            15 / 1  25 / 1     50 / 0.99                                                            80 / 0.97  100 / 0.97  115 / 0.96  115 / 0.98
+                                                                                                                                                          95 / 0.95
+1.5 Ton  3/8"  5/8"            15 / 1  25 / 1     50 / 1                                                               80 / 0.99  100 / 0.99  115 / 0.99  95 / 0.98
+                                                                                                                                                          85 / 0.93
+               3/4"            15 / 1  25 / 1     50 / 1                                                               80 / 0.99  100 / 0.99  115 / 0.99  85 / 0.97
+
+2 Ton    3/8"  5/8"            15 / 1  25 / 1     50 / 0.99                                                            80 / 0.98  100 / 0.97  100 / 0.96   75 / 0.9
+                                                                                                                                                          75 / 0.96
+               3/4"            15 / 1  25 / 1     50 / 1                                                               80 / 0.99  100 / 0.99  100 / 0.99  75 / 0.98
+                                                                                                                                                          65 / 0.95
+2.5 Ton  3/8"  5/8"            15 / 1  25 / 0.99  50 / 0.98                                                            80 / 0.97  95 / 0.96   90 / 0.94   65 / 0.98
+                                                                                                                                                          50 / 0.94
+               3/4"            15 / 1  25 / 1     50 / 0.99                                                            80 / 0.99  95 / 0.98   90 / 0.98   50 / 0.97
+                                                                                                                                                           15 / 0.9
+               5/8"            15 / 1  25 / 0.99  50 / 0.97                                                            80 / 0.95  85 / 0.94   80 / 0.92   15 / 0.96
+
+3 Ton    3/8"  3/4"            15 / 1  25 / 1     50 / 0.99                                                            80 / 0.98  85 / 0.98   80 / 0.97
+
+               7/8"            15 / 1  25 / 1     50 / 1                                                               80 / 0.99  85 / 0.99   80 / 0.99
+
+3.5 Ton  3/8"  3/4"            15 / 1  25 / 0.99  50 / 0.98                                                            80 / 0.97  80 / 0.97   70 / 0.96
+
+               7/8"            15 / 1  25 / 1     50 / 0.99                                                            80 / 0.99  80 / 0.99   70 / 0.98
+
+4 Ton    3/8"  3/4"            15 / 1  25 / 0.99  50 / 0.98                                                            75 / 0.97  70 / 0.96   60 / 0.95
+
+               7/8"            15 / 1  25 / 1     50 / 0.99                                                            75 / 0.99  70 / 0.98   60 / 0.98
+
+5 Ton    3/8"  3/4"            15 / 1  25 / 0.99  50 / 0.97                                                            65 / 0.95  45 / 0.94   30 / 0.92
+
+               7/8"            15 / 1  25 / 0.99  50 / 0.99                                                            65 / 0.98  45 / 0.97   30 / 0.96
+
+NOTES:
+1) Maximum Equivelent Line Length may not exceed 250'
+2) Maximum Actual Line Length may not exceed 200'
+3) Light Grey shaded areas are considered long line and may require accessories as recommended in Long Line Set Guide
+4) Refer to supplemental Long Line Set Guide for applications that require liquid line size other than 3/8"
+5) DO NOT use suction line traps in the suction riser as this adds additional unwanted pressure drop in the system
+
+               SINGLE AND
+               TWO STAGE
+               HEAT PUMPS
+
+                                                                                                                                                                      9
+Refrigerant Line Size Information
+WP15AZ
+
+Refrigerant Line Size Information (Con't.)
+
+                                                   SINGLE- AND TWO-STAGE HEAT PUMPS
+
+                                                             OUTDOOR UNIT ABOVE OR BELOW INDOOR UNIT
+
+    UNIT     MAX.                  SUCTION                   EQUIVALENT LENGTH (METERS)
+
+    SIZE LILNIQEUSIIDZE LINE SIZE           0-5    5.5-8     8.5-15                                                    15.5-24    24.5-30    30.5-38    38.5-46
+
+                                                             MAXIMUM VERTICAL SEPARATION/CAPACITY MULTIPLIER                                            35 / 0.95
+                                                                                                                                                        35 / 0.98
+                                   1/2"     5 / 1  8 / 1     15 / 0.99                                                 24 / 0.97  30 / 0.97  35 / 0.96  35 / 0.98
+                                                                                                                                                        29 / 0.95
+    1.5 Ton  3/8"                  5/8"     5 / 1  8 / 1     15 / 1                                                    24 / 0.99  30 / 0.99  35 / 0.99  29 / 0.98
+                                                                                                                                                        26 / 0.93
+                                   3/4"     5 / 1  8 / 1     15 / 1                                                    24 / 0.99  30 / 0.99  35 / 0.99  26 / 0.97
+                                                                                                                                                        23 / 0.9
+    2 Ton    3/8"                  5/8"     5 / 1  8 / 1     15 / 0.99                                                 24 / 0.98  30 / 0.97  30 / 0.96  23 / 0.96
+                                                                                                                                                        23 / 0.98
+                                   3/4"     5 / 1  8 / 1     15 / 1                                                    24 / 0.99  30 / 0.99  30 / 0.99  20 / 0.95
+                                                                                                                                                        20 / 0.98
+    2.5 Ton  3/8"                  5/8"     5 / 1  8 / 0.99  15 / 0.98                                                 24 / 0.97  29 / 0.96  27 / 0.94  15 / 0.94
+                                                                                                                                                        15 / 0.97
+                                   3/4"     5 / 1  8 / 1     15 / 0.99                                                 24 / 0.99  29 / 0.98  27 / 0.98
+                                                                                                                                                         5 / 0.9
+                                   5/8"     5 / 1  8 / 0.99  15 / 0.97                                                 24 / 0.95  26 / 0.94  24 / 0.92  5 / 0.96
+
+    3 Ton    3/8"                  3/4"     5 / 1  8 / 1     15 / 0.99                                                 24 / 0.98  26 / 0.98  24 / 0.97
+
+                                   7/8"     5 / 1  8 / 1     15 / 1                                                    24 / 0.99  26 / 0.99  24 / 0.99
+
+    3.5 Ton  3/8"                  3/4"     5 / 1  8 / 0.99  15 / 0.98                                                 24 / 0.97  24 / 0.97  21 / 0.96
+
+                                   7/8"     5 / 1  8 / 1     15 / 0.99                                                 24 / 0.99  24 / 0.99  21 / 0.98
+
+    4 Ton    3/8"                  3/4"     5 / 1  8 / 0.99  15 / 0.98                                                 23 / 0.97  21 / 0.96  18 / 0.95
+
+                                   7/8"     5 / 1  8 / 1     15 / 0.99                                                 23 / 0.99  21 / 0.98  18 / 0.98
+
+    5 Ton 3/8" 3/4" 5 / 1 8 / 0.99 15 / 0.97 20 / 0.95 14 / 0.94 9 / 0.92
+                                   7/8"     5 / 1  8 / 0.99  15 / 0.99                                                 20 / 0.98  14 / 0.97  9 / 0.96
+
+NOTES:
+1) Maximum Equivelent Line Length may not exceed 76 meters
+2) Maximum Actual Line Length may not exceed 61 meters
+3) Light Grey shaded areas are considered long line and may require accessories as recommended in Long Line Set Guide
+4) Refer to supplemental Long Line Set Guide for applications that require liquid line size other than 9.5mm
+5) DO NOT use suction line traps in the suction riser as this adds additional unwanted pressure drop in the system
+
+10
+                                                                                                                    Performance Data
+                                                                                                                    WP15AZ
+
+Performance Data @ AHRI Standard Conditions - Cooling
+
+DESIGNATED TESTED COMBINATION (DTC)
+
+OUTDOOR  AIR HANDLER       TOTAL         NET            NET               INDOOR    47 DEGREE      47   17 DEGREE      17 REGION
+   UNIT                  CAPACITY     SENSIBLE        LATENT SEER2 EER2  CFM [L/S]   HEATING    DEGREE   HEATING    DEGREE IV
+                        BTU/H [kW]   BTU/H [kW]     BTU/H [kW]                       CAPACITY            CAPACITY
+                                                                                    BTU/H [KW]    COP   BTU/H [KW]    COP HSPF2
+
+WP15AZ18AJ2N RH2TZ2417STANN 17,100 [5.0] 13,100 [3.8] 4,000 [1.2] 15.2 11.7 ,625 [295.0] 17,100 [5.0] 3.87 11,600 [3.4] 2.60 7.8
+
+WP15AZ24AJ2N RH2TZ2417STANN 22,800 [6.7] 17,400 [5.1] 5,400 [1.6] 15.2 11.7 ,775 [365.8] 22,600 [6.6] 3.88 15,600 [4.6] 2.80 7.8
+
+WP15AZ30AJ2N RH2TZ3617STANN 28,400 [8.3] 21,800 [6.4] 6,600 [1.9] 15.2 11.7 ,900 [424.8] 28,400 [8.3] 3.62 19,700 [5.8] 2.60 7.8
+
+WP15AZ36AJ2N RH2TZ3617STANN 34,200 [10.0] 26,200 [7.7] 8,000 [2.3] 15.2 11.7 1,050 [495.5] 34,200 [10.0] 3.62 24,400 [7.2] 2.70 7.8
+
+WP15AZ42AJ2N RH2TZ4821STANN 40,000 [11.7] 30,500 [8.9] 9,500 [2.8] 15.2 11.7 1,325 [625.3] 39,500 [11.6] 3.95 28,200 [8.3] 2.90 7.8
+
+WP15AZ48AJ2N RH2TZ4821STANN 45,500 [13.3] 35,000 [10.3] 10,500 [3.1] 15.2 11.7 1,450 [684.3] 45,000 [13.2] 3.92 33,200 [9.7] 2.90 7.8
+
+WP15AZ60AJ2N RH2TZ6024STANN 57,000 [16.7] 43,500 [12.7] 13,500 [4.0] 15.2 11.7 1,800 [849.5] 57,000 [16.7] 4.04 42,500 [12.5] 3.00 7.8
+
+NOTE: This data includes DTC (Designated Test Combination) ratings and is for reference purposes only. A full listing of official ratings and system match-ups, along with
+       downloadable certificates, can be accessed from the AHRI website: www.ahridirectory.org.
+
+[ ] Designates Metric Conversions
+
+          Outdoor Unit                 Air Handler  Total Capacity  Net Sensible   Net Latent   SEER2   EER2        Indoor CFM                                              47 Degree
+         WP15AZ18AJ2N              RH2TZ2417STANN    BTU/H [kW]     BTU/H [kW]    BTU/H [kW]     15.2   11.7            [L/s]                                               Heating Ca-
+         WP15AZ24AJ2N              RH2TZ2417STANN    17100 [5.0]    13100 [3.8]   4000 [1.2]     15.2   11.7
+         WP15AZ30AJ2N              RH2TZ3617STANN    22800 [6.7]    17400 [5.1]   5400 [1.6]     15.2   11.7                                                                   pacity
+         WP15AZ36AJ2N              RH2TZ3617STANN    28400 [8.3]    21800 [6.4]   6600 [1.9]     15.2   11.7
+         WP15AZ42AJ2N              RH2TZ4821STANN   34200 [10.0]    26200 [7.7]   8000 [2.3]     15.2   11.7        625 [295.0] 17100 [5.0]
+         WP15AZ48AJ2N              RH2TZ4821STANN   40000 [11.7]    30500 [8.9]   9500 [2.8]     15.2   11.7
+         WP15AZ60AJ2N              RH2TZ6024STANN   45500 [13.3]    35000 [10.3]  10500 [3.1]    15.2   11.7        775 [365.8] 22600 [6.6]
+                                                    57000 [16.7]    43500 [12.7]  13500 [4.0]
+                                                                                                                    900 [424.8] 28400 [8.3]
+
+                                                                                                                    1050 [495.5] 34200 [10.0]
+
+                                                                                                                    1325 [625.3] 39500 [11.6]
+
+                                                                                                                    1450 [684.3] 45000 [13.2]
+
+                                                                                                                    1800 [849.5] 57000 [16.7]
+
+                                                                                                                                                                            11
+GENERAL TERMS OF LIMITED WARRANTY*                                           Parts............................................................. Five (5)Years
+
+Rheem will furnish a replacement for any part of this product
+which fails in normal use and service within the applicable
+period stated, in accordance with the terms of the limited
+warranty.
+
+ *For complete details of the Limited and Conditional Warranties, including
+applicable terms and conditions, contact your local contractor or the
+Manufacturer for a copy of the product warranty certificate.
+
+Before proceeding with installation, refer to installation instructions packaged with each model, as well as complying with all Federal,
+                                                   State, Provincial, and Local codes, regulations, and practices.
+
+                  © 2023 Rheem Manufacturing Company. Rheem trademarks owned by Rheem Manufacturing Company.
+In keeping with its policy of continuous progress and product improvement, Rheem reserves the right to make changes without notice.
+
+Rheem Heating, Cooling & Water Heating · 5600 Old Greenwood Road             Rheem Canada Ltd./Ltée · 125 Edgeware Road, Unit 1
+                Fort Smith, Arkansas 72908 · www.rheem.com                           Brampton, Ontario · L6Y 0P5 · rheem.ca
+
+                                                                             PRINTED IN U.S.A. 6/23 QG FORM NO. P33-837 REV. 1
+

--- a/data/heat-pumps/rheem/endeavor-line-select-wsp14az/raw.txt
+++ b/data/heat-pumps/rheem/endeavor-line-select-wsp14az/raw.txt
@@ -1,0 +1,442 @@
+                                                                                                                                                                             Heat Pumps
+                                                                                                                                                                             WSP14AZ
+
+Endeavor® Line Select® Series
+           iC Heat Pumps
+
+WSP14AZ
+
+Cooling Efficiencies up to: 14.3 SEER2/10.4 EER2
+Heating Efficiencies up to: 7.5 HSPF2
+Nominal Sizes: 11/2 to 2.5 Ton [5.28 to 8.79 kW]
+Cooling Capacities: 17.1 to 55.5 kBTU [5.0 to 16.3 kW]
+
+                                                                                                                                                                                                                                   FORM NO. P33-830 REV. 2
+Table of Contents
+WSP14AZ
+
+                                          Table of Contents
+
+                   Features & Benefits...................................................................3
+                   Model Number Identification.....................................................4
+                   General Data/Electrical Data.....................................................5
+                   Accessories...............................................................................6
+                   Weighted Sound Power........................................................... 6
+                   Unit Dimensions........................................................................7
+                   Clearances................................................................................8
+                   Refrigerant Line Size Information........................................ 9-10
+                   Performance Data...................................................................11
+                   Limited Warranty.....................................................................12
+
+2
+                                                               Features and Benefits
+                                                               WSP14AZ
+
+Features and Benefits
+
+· Fully Louvered Steel Cabinet: Features durable construction
+   to add protection from yard hazards, weather corrosion
+
+· Two-Stage Scroll Compressor: Features two speeds (high
+   and low) of cooling and heating, providing more precise
+   temperature control, lower humidity and greater efficiency
+   when compared to single stage compressors
+
+· Optimized 7 mm Coil Design: Allows for improved airflow,
+   heat transfer and energy consumption
+
+· Easily Accessible Control Box: Ease of installation and
+   serviceability
+
+                                                               3
+Model Number Identification
+WSP14AZ
+
+ Heat Pumps
+
+   W      SP                       14     A         Z                          18        A                           J    2     N         A
+
+   Brand  Product                  SEER2  Region Refrigerant                   Capacity  Major Series Voltage             Type  Controls  Minor Series
+          Category
+
+W - Rheem Select SP - Legacy       14 - 14.3 SEER2 A - All Regions Z - R-410A  18 - 18,000 [5.28 kW] A - 1st Design J - 208/230/1/60 2 - 2-Stage N - Non-Communicating A - 1st Design
+                        Heat Pump                                              24 - 24,000 [7.03 kW]
+                                                                               30 - 30,000 [8.79 kW]
+
+[ ] Designates Metric Conversions
+
+   AVAILABLE MODELS                                                                                     DESCRIPTION
+   WSP14AZ18AJ2NA                  1-1/2 ton 14.3 SEER2 Two-Stage Air Conditioner-208/230/1/60
+   WSP14AZ24AJ2NA                  2 ton 14.3 SEER2 Two-Stage Air Conditioner-208/230/1/60
+   WSP14AZ30AJ2NA                  2-1/2 ton 14.3 SEER2 Two-Stage Air Conditioner-208/230/1/60
+
+                                STANDARD EQUIPMENT
+
+   R-410A Refrigerant
+   Scroll Compressor
+   Field Installed Filter Drier
+   Front Seating Service Valves
+   Internal Pressure Relief Valve
+   Internal Thermal Overload
+   Long Line capability
+   Low Ambient capability with Kit
+   3-4-5 Expanded Valve Space
+   Optimized Venturi Airflow
+   Single row condenser coil
+
+        WP14AZ18AJ1NA
+   Rust resistant screws
+   QR coWdPe14AZ18AJ2NA
+   ExterWnaPl 1g4aAugZe24pAoJr2tsNA
+   ServiWcePt1ra4yAsZ30AJ2NA
+
+        WP14AZ36AJ2NA
+
+        WP14AZ42AJ2NA
+
+        WP14AZ48AJ2NA
+        WP14AZ60AJ2NA
+
+                                                                                         R-410a Refrigerant
+
+                                                                                         Scroll Compressor
+
+                                                                                         Field Installed Filter Drier
+
+                                                                                         Front Seating Service Valves
+
+                                                                                         Internal Pressure Relief Valve
+
+                                                                                         Internal Thermal Overload
+
+                                                                                         Long Line capability
+
+                                                                                         Low Ambient capability with Kit
+
+4                                                                                        3-4-5 Expanded Valve Space
+
+                                                                                         Composite Basepan
+                                                                                                      General Data/Electrical Data
+                                                                                                      WSP14AZ
+
+General Data                                    Liquid Line O.D. - in.    WSP14AZ18A    WSP14AZ24A    WSP14AZ30A
+                                              Suction Line O.D. - in.           1.5           2.0           2.5
+  MODEL NO.
+  Nominal Tonnage                       Net face area - Outer Coilp6            3/8           3/8           3/8
+  Valve Connections                               Tube diameter - in.           3/4           3/4           3/4
+                                                      Number of rows            88            103           127
+  Refrigerant (R410A) furnished oz.¹                      Fins per inch                   Scroll
+  Compressor Type                                                              14.5                        18.1
+  Outdoor Coil                                          Diameter - in.         0.276         14.5          0.276
+                                                    Number of blades                         0.276
+  Outdoor Fan                                                                    1                           1
+                                                              Motor hp          22             1            22
+  Shipping weight - lbs.                                            CFM                       22
+  Operating weight - lbs.                                          RPM          18                          22
+                                                                   watts         3            18             2
+                                                                                1/7            3            1/6
+                                                                               2181           1/7          2514
+                                                                               1075          2181           850
+                                                                                154          1075           165
+                                                                                143           154           170
+                                                                                135           145           163
+                                                                                              137
+
+Electrical Data
+
+Line Voltage Data (Volts-Phase-Hz)        Rated load amps                 208/230-1-60  208/230-1-60  208/230-1-60
+Maximum overcurrent protection (amps)²  Locked rotor amps                       20            25            25
+Minimum circuit ampacity³                                                       11            15            16
+Compressor                                   Full load amps
+                                        Locked rotor amps                        9            11            13
+Condenser Fan Motor                                                             56            66            78
+
+                                                                                0.8           0.8           1.0
+                                                                                1.5           1.5           2.6
+
+¹Refrigerant charge sufficient for 15 ft. length of refrigerant lines. For longer line set requirements see the installation instructions for information about set length and additional
+refrigerant charge required.
+²HACR type circuit breaker of fuse.
+³Refer to National Electrical Code manual to determine wire, fuse and disconnect size requirements.
+
+                                                                                                                                                                                           5
+Accessories/Weighted Sound Power
+WSP14AZ
+
+Accessories
+
+                           MODEL NO.                                                 WSA14AZ18A      WSA14AZ24A      WSA14AZ30A
+                                                                                     44-17402-44     44-17402-44     44-17402-44
+Compressor crankcase heater*                                                           RXAD-A08        RXAD-A08        RXAD-A08
+                                                                                     68-23427-26     68-23427-26     68-23427-26
+Low ambient control
+                                                                                         SK-A1           SK-A1           SK-A1
+Compressor sound cover                                                                 RXMD-B01        RXMD-B01        RXMD-B01
+                                                                                       RXAC-A07        RXAC-A07        RXAC-A07
+Compressor hard start kit                                                              RXAB-A07        RXAB-A07        RXAB-A07
+                                                                                    200RD2T3TVLC    200RD2T3TVLC    200RD2T3TVLC
+Compressor time delay                                                                 61-AMG24V       61-AMG24V       61-AMG24V
+                                                                                    200RD2T3TVLC    200RD2T3TVLC    200RD2T3TVLC
+Low pressure control                                                               61-AMG120/240V  61-AMG120/240V  61-AMG120/240V
+
+High pressure control
+
+Liquid Line Solenoid                  Solenoid Valve
+(24 VAC, 50/60 Hz)                    Solenoid Coil
+
+Liquid Line Solenoid                  Solenoid Valve
+(120/240 VAC, 50/60 Hz)               Solenoid Coil
+
+*Bi-flow kits are required when installing a liquid line solenoid on a heat pump.
+
+Weighted Sound Power Level (dBA)
+
+   UNIT SIZE -                STANDARD                                             TYPICAL OCTAVE BAND SPECTRUM (dBA without tone adjustment)
+
+   VOLTAGE, SERIES            RATING (DBA)            125                          250   500       1000  2000      4000                        8000
+
+   WSP14AZ18AJ2                   73                  47.8                         51.7  60.8      65.5  61.7      56.4                        48.6
+
+   WSP14AZ24AJ2                   74                  125.0                        53.0  60.0      67.0  58.6      55.5                        47.6
+
+   WSP14AZ30AJ2                   76                  49.6                         67.7  63.4      68.6  62.1      63.7                        50.8
+
+NOTE: Tested in accordance with AHRI Standard 270-08 (not listed in AHRI)
+
+6
+                                                                                                                      Unit Dimensions
+                                                                                                                      WSP14AZ
+
+Unit Dimensions
+
+                                                 OPERATING                                             SHIPPING
+
+   MODEL         H (Height)                      L (Length)   W (Width)                    H (Height)  L (Length)     W (Width)
+      NO.
+            INCHES  mm                           INCHES  mm   INCHES  mm    INCHES         mm          INCHES    mm   INCHES  mm
+WSP14AZ18A
+WSP14AZ24A  35.38   899                          23.63   600  23.63   600   35.63          905         24.75     629  24.75   629
+WSP14AZ30A
+            35.38   899                          23.63   600  23.63   600   35.63          905         24.75     629  24.75   629
+
+            35.38   899                          27.63   702  27.63   702   35.63          905         28.75     730  28.75   730
+
+                                                                         H
+
+                                              W                          LOW VOLTAGE                                  HIGH VOLTAGE
+      L                                                                       7/8 [22 mm]                             13/32 [27 mm]
+                                                                                                                      HOLE DIAMETER
+                          SEE DETAIL A                                HOLE DIAMETER
+[ ] Designates Metric Conversions                                                                                         SERVICE
+                                                                          SERVICE                                         FITTING
+                                                                            FITTING
+
+                                                                              LIQUID LINE                          VAPOR LINE
+                                                                            CONNECTION                             CONNECTION
+
+                                                                                                       DETAIL A                               Illustration
+                                                                                                                                           ST-A1331-01
+                                                                                                                                       Rev. 10-20-2022
+
+                                                                                                                                                            7
+8                                                                                                                                                                                                                                     Clearances
+                                                                                                                                                                                                                                  WSP14AZ
+   CLEARANCES
+                                                                                                                                                                                             WALL
+                   WALL
+                                                                                                                                                                                                            24
+                            6                                                                                                                                                                            (609.6)
+                         (152.4)                                                                                                                                                                         Service
+
+     24                    12                                                                                                                                                         12                                   WALL
+   (609.6)               (304.8)                                                                                                                                                    (304.8)
+   Service
+
+                                                                                                                                                                                                                     6
+                                                                                                                                                                                                                  (152.4)
+
+               6
+            (152.4)
+
+                                                                                                                                                                                               12
+                                                                                                                                                                                             (304.8)
+
+              24                         WALL                                                                                                                                                  24
+            (609.6)                                                                                                                                                                          (609.6)
+            Service                         24                                                                                                                                               Service
+                                         (609.6)
+                                         Service
+
+     18                           24                       24
+   (457.2)                     (609.6)                  (609.6)
+
+                         24 recommended           24 recommended
+                         6 minimum                6 minimum
+
+   NOTE: NUMBERS IN () = mm
+
+   IMPORTANT: When installing multiple units in an alcove, roof well or partially enclosed area, ensure there is adequate ventillation to prevent re-circulation of discharge air.
+
+                                                                                                                                                                                                                  ST-A1225-01-00
+                                                                                                                                                         Refrigerant Line Size Information
+                                                                                                                                                         WSP14AZ
+
+Refrigerant Line Size Information
+
+                                                14.3 SEER2 SINGLE-STAGE AIR-CONDITIONERS
+
+                                Apply Long                                        Equivalent Length (Feet)
+                                Line Guide-
+                               lines if Linear  < 25  26-50 51-75 76-100 101-125 126-150 151-175                                                         176-200  201-225  226-250
+                                Line Length
+UNIT     Allowable  Allowable                                            Maximum Vertical Rise
+SIZE       Liquid    Suction      Exceeds             (Outdoor Unit Below Indoor Unit) * / Capacity Multiplier
+                    Line Size  Those Shown
+         Line Size             Below (Feet)
+
+         1/4"       5/8"       /                25 / 1.00 50 / 0.99 62 / 0.98 43 / 0.98 24 / 0.97 5 / 0.97 NR                                            NR       NR       NR
+
+         5/16"      5/8"       188              25 / 1.00 50 / 0.99 75 / 0.98 98 / 0.98 93 / 0.97 88 / 0.97 83 / 0.96 78 / 0.96 73 / 0.95 68 / 0.94
+          3/8"
+1.5 Ton   1/4"      5/8"       125              25 / 1.00 50 / 0.99 75 / 0.98 100 / 0.98 100 / 0.97 100 / 0.97 100 / 0.96 100 / 0.96 100 / 0.95 100 / 0.94
+**SEE    5/16"
+NOTE 3              3/4" **    /                25 / 1.00 50 / 1.00 62 / 0.99 43 / 0.99 24 / 0.99 5 / 0.99 NR                                            NR       NR       NR
+
+                    3/4" **    188              25 / 1.00 50 / 1.00 75 / 0.99 98 / 0.99 93 / 0.99 88 / 0.99 83 / 0.99 78 / 0.98 73 / 0.98 68 / 0.98
+
+         3/8"       3/4" **    125              25 / 1.00 50 / 1.00 75 / 1.00 100 / 0.99 100 / 0.99 100 / 0.99 100 / 0.99 100 / 0.98 100 / 0.98 100 / 0.98
+
+         1/4"       5/8"       /                25 / 0.99 50 / 0.98 21 / 0.97 NR  NR                                                             NR  NR  NR       NR       NR
+
+         5/16"      5/8"       180              25 / 0.99 50 / 0.98 75 / 0.97 87 / 0.96 77 / 0.95 69 / 0.94 61 / 0.93 53 / 0.92 45 / 0.91 37 / 0.90
+
+2 Ton    3/8"       5/8"       120              25 / 0.99 50 / 0.98 75 / 0.97 100 / 0.96 100 / 0.95 100 / 0.94 98 / 0.93 95 / 0.92 92 / 0.91 89 / 0.90
+
+         1/4"       3/4"       /                25 /1.00 50 / 1.00 21 / 0.99 NR   NR                                                             NR  NR  NR       NR       NR
+
+         5/16"      3/4"       180              25 /1.00 50 / 1.00 75 / 0.99 87 / 0.99 77 / 0.98 69 / 0.98 61 / 0.98 53 / 0.97 45 / 0.97 37 / 0.96
+
+         3/8"       3/4"       120              25 / 1.00 50 / 1.00 75 / 0.99 100 / 0.99 100 / 0.98 100 / 0.98 98 / 0.98 95 / 0.97 93 / 0.97 90 / 0.96
+
+         5/16"      5/8"       148              25 / 0.99 50 / 0.98 75 / 0.96 70 / 0.94 59 / 0.93 48 / 0.91 36 / 0.90 NR                                          NR       NR
+
+2.5 Ton  3/8"       5/8"       98               25 / 0.99 50 / 0.98 75 / 0.96 100 / 0.94 98 / 0.93 94 / 0.91 90 / 0.90 NR                                         NR       NR
+
+         5/16"      3/4"       148              25 / 1.00 50 / 0.99 75 / 0.99 70 / 0.98 59 / 0.98 48 / 0.97 36 / 0.96 25 / 0.96 13 / 0.95 NR
+
+         3/8"       3/4"       98               25 / 1.00 50 / 0.99 75 / 0.99 100 / 0.98 98 / 0.98 94 / 0.97 90 / 0.96 86 / 0.96 82 / 0.95 78 / 0.95
+
+1)  Do not exceed 200 ft linear line length.
+2)  *Do not exceed 100 ft vertical separation if outdoor unit is above indoor unit.
+3) **3/4" suction line should only be used for 1.5 ton systems if outdoor unit is below or at same level as indoor to assure proper oil return.
+4)  Always use the smallest liquid line allowable to minimize refrigerant charge.
+5)  Applications shaded in light gray indicate capacity multipliers between 0.90 and 0.96 which are not recommended, but are allowed.
+6)  Applications shaded in dark gray are not recommended due to excessive liquid or suction pressure drop.
+
+                                                                                                                                                                               9
+Refrigerant Line Size Information
+WSP14AZ
+
+Refrigerant Line Size Information (Con't.)
+
+                                                       14.3 SEER2 SINGLE-STAGE AIR-CONDITIONERS
+
+                                              Apply Long                                      Equivalent Length (Meters)
+
+             Allowable    Allowable liLnienseiGf Luiindeea-r < 8  8-15 16-23 24-30 31-38 39-46 47-53 54-61 62-69 70-76
+
+    Unit     Liquid                Suction    Line Length
+
+    Size     Line Size             Line Size  Exceeds                                         Maximum Vertical Rise
+
+             mm [in.]              mm [in.]   Those Shown         (Outdoor Unit Below Indoor Unit) * / Capacity Multiplier
+
+                                              Below (Meters)
+
+             6.35 [1/4]   15.88 [5/8]         /               8 / 1.00 15 / 0.99 19 / 0.98 13 / 0.98 7 / 0.97 2 / 0.97 NR                                NR  NR  NR
+
+ 5.3 KW      7.94 [5/16]  15.88 [5/8]         57              8 / 1.00 15 / 0.99 23 / 0.98 30 / 0.98 28 / 0.97 27 / 0.97 25 / 0.96 24 / 0.96 22 / 0.95 21 / 0.94
+[1.5 Ton]    9.53 [3/8]   15.88 [5/8]
+                                              38              8 / 1.00 15 / 0.99 23 / 0.98 30 / 0.98 30 / 0.97 30 / 0.97 30 / 0.96 30 / 0.96 30 / 0.95 30 / 0.94
+
+    **SEE 6.35 [1/4]      19.05 [3/4]**       /               8 / 1.00 15 / 1.00 19 / 0.99 13 / 0.99 7 / 0.99 2 / 0.99 NR                                NR  NR  NR
+    NOTE 3
+             7.94 [5/16] 19.05 [3/4]**        57              8 / 1.00 15 / 1.00 23 / 0.99 30 / 0.99 28 / 0.99 27 / 0.99 25 / 0.99 24 / 0.98 22 / 0.98 21 / 0.98
+
+             9.53 [3/8]   19.05 [3/4]**       38              8 / 1.00 15 / 1.00 23 / 0.99 30 / 0.99 30 / 0.99 30 / 0.99 30 / 0.99 30 / 0.98 30 / 0.98 30 / 0.98
+
+             6.35 [1/4]   15.88 [5/8]         /               8 / 0.99 15 / 0.98 6 / 0.97 NR     NR                                              NR  NR  NR  NR  NR
+
+             7.94 [5/16] 15.88 [5/8]          55              8 / 0.99 15 / 0.98 23 / 0.97 27 / 0.96 23 / 0.95 21 / 0.94 19 / 0.93 16 / 0.92 14 / 0.91 11 / 0.90
+
+    7.0 KW   9.53 [3/8]   15.88 [5/8]         37              8 / 0.99 15 / 0.98 23 / 0.97 30 / 0.96 30 / 0.95 30 / 0.94 30 / 0.93 29 / 0.92 28 / 0.91 27 / 0.90
+    [2 Ton]  6.35 [1/4]   19.05 [3/4]
+                                              /               8 / 1.00 15 / 1.00 6 / 0.99 NR     NR                                              NR  NR  NR  NR  NR
+
+             7.94 [5/16] 19.05 [3/4]          55              8 / 1.00 15 / 1.00 23 / 0.99 27 / 0.99 23 / 0.98 21 / 0.98 19 / 0.98 16 / 0.97 14 / 0.97 11 / 0.96
+
+             9.53 [3/8]   19.05 [3/4]         37              8 / 1.00 15 / 1.00 23 / 0.99 30 / 0.99 30 / 0.98 30 / 0.98 30 / 0.98 29 / 0.97 28 / 0.97 27 / 0.96
+
+             7.94 [5/16] 15.88 [5/8]          45              8 / 0.99 15 / 0.98 23 / 0.96 21 / 0.94 18 / 0.93 15 / 0.91 11 / 0.90 NR                        NR  NR
+
+8.8 KW       9.53 [3/8]   15.88 [5/8]         30              8 / 0.99 15 / 0.98 23 / 0.96 30 / 0.94 30 / 0.93 29 / 0.91 27 / 0.90 NR                        NR  NR
+[2.5 Ton]    7.94 [5/16]  19.05 [3/4]
+                                              45              8 / 1.00 15 / 0.99 23 / 0.99 21 / 0.98 18 / 0.98 15 / 0.97 11 / 0.96 8 / 0.96 4 / 0.95 NR
+
+             9.53 [3/8]   19.05 [3/4]         30              8 / 1.00 15 / 0.99 23 / 0.99 30 / 0.98 30 / 0.98 29 / 0.97 27 / 0.96 26 / 0.96 25 / 0.95 24 / 0.95
+
+1)  Do not exceed 200 ft linear line length.
+2)  *Do not exceed 100 ft vertical separation if outdoor unit is above indoor unit.
+3) **3/4" suction line should only be used for 1.5 ton systems if outdoor unit is below or at same level as indoor to assure proper oil return.
+4)  Always use the smallest liquid line allowable to minimize refrigerant charge.
+5)  Applications shaded in light gray indicate capacity multipliers between 0.90 and 0.96 which are not recommended, but are allowed.
+6)  Applications shaded in dark gray are not recommended due to excessive liquid or suction pressure drop.
+
+10
+                                                                                                                        Performance Data
+                                                                                                                        WSP14AZ
+
+Performance Data @ AHRI Standard Conditions - Cooling
+
+DESIGNATED TESTED COMBINATION (DTC)
+
+OUTDOOR                  TOTAL       NET  NET                                 INDOOR    47 DEGREE      47   17 DEGREE      17 REGION
+   UNIT                CAPACITY                                              CFM [L/S]   HEATING    DEGREE   HEATING    DEGREE IV
+         AIR HANDLER  BTU/H [kW]     SENSIBLE LATENT SEER2 EER2                          CAPACITY            CAPACITY
+                                                                                        BTU/H [KW]    COP   BTU/H [KW]    COP HSPF2
+                                     BTU/H [kW] BTU/H [kW]
+
+WSP14AZ18AJ2 RH2TZ2417STANNJ 17,100 [5.0] 12,800 [3.8] 4,300 [1.3] 14.3 9.0  ,585 [276.1] 17,100 [5.0] 3.45 11,000 [3.2] 2.38 7.5
+WSP14AZ24AJ2 RH2TZ2417STANNJ 22,800 [6.7] 16.600 [4.9] 6,200 [1.6] 14.3 9.0
+WSP14AZ30AJ2 RH2TZ3617STANNJ 28,500 [8.4] 21,300 [6.2] 7,200 [2.1] 14.3 9.0  ,735 [346.9] 22,800 [6.7] 3.45 15,000 [4.4] 2.48 7.5
+
+                                                                             ,910 [429.5] 28,500 [8.4] 3.45 18,000 [5.3] 2.50 7.5
+
+NOTE: This data includes DTC (Designated Test Combination) ratings and is for reference purposes only. A full listing of official ratings and system match-ups, along with
+       downloadable certificates, can be accessed from the AHRI website: www.ahridirectory.org.
+
+[ ] Designates Metric Conversions
+
+                                                                                                                                                                            11
+GENERAL TERMS OF LIMITED WARRANTY*                                           Parts............................................................. Five (5)Years
+
+Rheem will furnish a replacement for any part of this product
+which fails in normal use and service within the applicable
+period stated, in accordance with the terms of the limited
+warranty.
+
+ *For complete details of the Limited and Conditional Warranties, including
+applicable terms and conditions, contact your local contractor or the
+Manufacturer for a copy of the product warranty certificate.
+
+Before proceeding with installation, refer to installation instructions packaged with each model, as well as complying with all Federal,
+                                                   State, Provincial, and Local codes, regulations, and practices.
+
+                  © 2023 Rheem Manufacturing Company. Rheem trademarks owned by Rheem Manufacturing Company.
+In keeping with its policy of continuous progress and product improvement, Rheem reserves the right to make changes without notice.
+
+               5600 Old Greenwood Road                                                  125 Edgeware Road, Unit 1
+Fort Smith, Arkansas 72908 · www.rheem.com                                   Brampton, Ontario · L6Y 0P5 · rheem.ca
+
+                                                                             PRINTED IN U.S.A. 11/23 QG FORM NO. P33-830 REV. 2
+


### PR DESCRIPTION
This is not a comprehensive set of files, but it contains some more kinds of files we should be collecting and versioning:

1. golden files (there's only one example, and it's not, in fact, actually accurate... but it's representative)
2. text equivalents of PDF files. These should be kept in sync with the PDF files, but since we consider both a kind of input into the rest of the process, and it's a bit slow to regenerate them each time, I think it makes sense to version them.

We continue to have the policy that more intermediate input (e.g. LLM output) should not be versioned since it can be easily regenerated and we're iterating through those stages in the pipeline a lot.